### PR TITLE
Enable Sauce Labs test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Using maven, add jitpack.io to your repositories and include it as a dependency:
     </repository>
     
 </repositories>
-
+```
+```xml
 <dependencies>
 
     <dependency>
@@ -95,6 +96,13 @@ If you have an idea for the framework, fork it and submit a pull-request!
  4. Tag the merge (with release notes) in the master branch with `x.x.x` (this will make this version available in jitpack).
  5. Create a new pull request from master to develop so all changes are back in develop.
  6. If approved merge master branch into develop.
+
+# Use with Sauce Labs
+ 1. get an API token for your sauce labs account
+ 2. upload the .app file as a zip to temporary [sauce storage](https://wiki.saucelabs.com/display/DOCS/Uploading+Mobile+Applications+to+Sauce+Storage+for+Testing)
+ 3. set the hub property to connect to saucelabs `https://<login-name>:<API-token>@ondemand.saucelabs.com:443/wd/hub`
+ 4. set the ipa/apk property to `sauce-storage:<zip-filename>.zip`
+ 5. run the test
 
 License
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.joss</groupId>
+    <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.6.3</version>
+    <version>0.8.0</version>
 
     <repositories>
         <repository>
@@ -16,7 +16,7 @@
     </repositories>
 
     <scm>
-        <url>https://github.com/jossjacobo/conductor-mobile</url>
+        <url>https://github.com/willowtreeapps/conductor-mobile</url>
     </scm>
 
     <dependencies>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -7,7 +7,6 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
-import io.appium.java_client.remote.IOSMobileCapabilityType;
 import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.service.local.flags.GeneralServerFlag;
@@ -93,7 +92,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
             DesiredCapabilities capabilities = onCapabilitiesCreated(getCapabilities(configuration));
 
             AppiumServiceBuilder builder = new AppiumServiceBuilder()
-                    .withArgument(GeneralServerFlag.LOG_LEVEL, configuration.logLevel().equals("")
+                    .withArgument(GeneralServerFlag.LOG_LEVEL, "".equals(configuration.logLevel())
                             ? "debug"
                             : configuration.logLevel());
 

--- a/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
@@ -284,6 +284,7 @@ public class LocomotiveConfig implements Config {
             default:
                 throw new IllegalArgumentException("Unknown platform: " + platformName());
         }
+        // Only add the full path for local tests.
         return (StringUtils.isEmpty(hub())) ? System.getProperty("user.dir") + app : app;
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
@@ -200,7 +200,7 @@ public class LocomotiveConfig implements Config {
     }
 
     private String getStringValue(String defaultPropertyKey, String testConfigValue, String jvmParamKey) {
-        String value = "";
+        String value = null;
         String defaultValue = getProperty(defaultPropertyKey);
         String jvmValue = JvmUtil.getJvmProperty(jvmParamKey);
 
@@ -284,6 +284,6 @@ public class LocomotiveConfig implements Config {
             default:
                 throw new IllegalArgumentException("Unknown platform: " + platformName());
         }
-        return System.getProperty("user.dir") + app;
+        return (StringUtils.isEmpty(hub())) ? System.getProperty("user.dir") + app : app;
     }
 }

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveConfigTest.java
@@ -186,6 +186,28 @@ public class LocomotiveConfigTest {
     }
 
     @Test
+    public void test_apk_full_path_remote() {
+        Config androidConfig = mock(Config.class);
+        when(androidConfig.apk()).thenReturn("sauce-storage:QAInternal.zip");
+        when(androidConfig.hub()).thenReturn("https://qa.login:SAUCE_LABS_API-TOKEN@ondemand.saucelabs.com:443/wd/hub");
+        when(androidConfig.platformName()).thenReturn(Platform.ANDROID);
+
+        LocomotiveConfig config = new LocomotiveConfig(androidConfig, null);
+        Assertions.assertThat(config.getAppFullPath()).isEqualTo("sauce-storage:QAInternal.zip");
+    }
+
+    @Test
+    public void test_ipa_full_path_remote() {
+        Config iosConfig = mock(Config.class);
+        when(iosConfig.ipa()).thenReturn("sauce-storage:QAInternal.zip");
+        when(iosConfig.hub()).thenReturn("https://qa.login:SAUCE_LABS_API-TOKEN@ondemand.saucelabs.com:443/wd/hub");
+        when(iosConfig.platformName()).thenReturn(Platform.IOS);
+
+        LocomotiveConfig config = new LocomotiveConfig(iosConfig, null);
+        Assertions.assertThat(config.getAppFullPath()).isEqualTo("sauce-storage:QAInternal.zip");
+    }
+
+    @Test
     public void test_platform_none_throws_on_full_path() {
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             public void call() throws Throwable {


### PR DESCRIPTION
To be able to run tests with saucelabs capabilities can not be sent with
empty string values. As a remedy string capabilities are now set to null
by default which prevents them from being sent if they are not set.
1. Instantiate string properties with null instead of an empty string
2. Use full path for app location only for local test execution
3. reverse log level string comparison to avoid NPE
4. add sauce labs instructions to readme
5. update develop version to 0.8.0