### PR TITLE
Store the test name for the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.8.6</version>
+    <version>0.9.0</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -7,7 +7,6 @@ import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.MobileCommand;
 import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidMobileCommandHelper;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.PerformsTouchID;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
@@ -53,7 +52,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     public AppiumDriver driver;
 
     private Map<String, String> vars = new HashMap<String, String>();
-    private String testName;
+    private String testMethodName;
 
     @Rule
     public TestRule watchman = this;
@@ -75,7 +74,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     @Before
     @BeforeMethod(alwaysRun = true)
     public void init(Method method) {
-        this.testName = method.getName();
+        this.testMethodName = method.getName();
 
         ConductorConfig config = new ConductorConfig();
         init(config);
@@ -872,7 +871,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
         return this;
     }
 
-    public String getTestName() {
-        return testName;
+    public String getTestMethodName() {
+        return testMethodName;
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -30,6 +30,8 @@ import org.pmw.tinylog.Logger;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
+
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.time.Duration;
 import java.util.*;
@@ -51,6 +53,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     public AppiumDriver driver;
 
     private Map<String, String> vars = new HashMap<String, String>();
+    private String testName;
 
     @Rule
     public TestRule watchman = this;
@@ -71,7 +74,9 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
 
     @Before
     @BeforeMethod(alwaysRun = true)
-    public void init() {
+    public void init(Method method) {
+        this.testName = method.getName();
+
         ConductorConfig config = new ConductorConfig();
         init(config);
     }
@@ -865,5 +870,9 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
         WebDriverWait wait = new WebDriverWait(driver, timeOutInSeconds, sleepInMillis);
         wait.until(condition);
         return this;
+    }
+
+    public String getTestName() {
+        return testName;
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -57,6 +58,9 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     @Rule
     public TestRule watchman = this;
 
+    @Rule
+    public TestName testNameRule = new TestName();
+
     public Locomotive getLocomotive() {
         return this;
     }
@@ -72,8 +76,17 @@ public class Locomotive extends Watchman implements Conductor<Locomotive> {
     }
 
     @Before
+    public void init() {
+        // For jUnit get the method name from a test rule.
+        this.testMethodName = testNameRule.getMethodName();
+
+        ConductorConfig config = new ConductorConfig();
+        init(config);
+    }
+
     @BeforeMethod(alwaysRun = true)
     public void init(Method method) {
+        // For testNG get the method name from an injected dependency.
         this.testMethodName = method.getName();
 
         ConductorConfig config = new ConductorConfig();


### PR DESCRIPTION
Adding the feature to store the test name during the initialization of Locomotive. This way it is available during all subsequent calls (like `onCapabilitiesCreated()`) for test projects.