### PR TITLE
Renaming getDriver to getAppium driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
             <version>1.3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.saucelabs</groupId>
+            <artifactId>sauce_testng</artifactId>
+            <version>2.1.23</version>
+        </dependency>
+
     </dependencies>
 
     <licenses>

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -59,6 +59,8 @@ public class ConductorConfig {
 
     // SauceLabs Authentication
     private SauceOnDemandAuthentication authentication;
+    private String sauceUserName;
+    private String sauceAccessKey;
 
     public ConductorConfig() {
         this(DEFAULT_CONFIG_FILE);
@@ -393,6 +395,14 @@ public class ConductorConfig {
         this.autoGrantPermissions = autoGrantPermissions;
     }
 
+    public String getSauceUserName() {return this.sauceUserName; }
+
+    public String getSauceAccessKey() {return this.sauceAccessKey; }
+
+    public void setSauceUserName (String sauceUserName) {this.sauceUserName = sauceUserName; }
+
+    public void setSauceAccessKey (String sauceAccessKey) {this.sauceAccessKey = sauceAccessKey; }
+
     public Platform getPlatformName() {
         return platformName;
     }
@@ -449,9 +459,7 @@ public class ConductorConfig {
         this.customCapabilities.putAll(customCapabilities);
     }
 
-    public SauceOnDemandAuthentication getAuthentication() {
-        String sauceUserName = System.getProperty("SAUCE_USERNAME");
-        String sauceAccessKey = System.getProperty("SAUCE_ACCESS_KEY");
+    public SauceOnDemandAuthentication getSauceAuthentication(String sauceUserName, String sauceAccessKey) {
 
         if (sauceUserName == null) {
             throw new InvalidArgumentException("Env var for SAUCE_USERNAME cannot be null");

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -1,6 +1,8 @@
 package com.joss.conductor.mobile;
 
+import com.saucelabs.common.SauceOnDemandAuthentication;
 import io.appium.java_client.CommandExecutionHelper;
+import org.openqa.selenium.InvalidArgumentException;
 import org.pmw.tinylog.Logger;
 import org.yaml.snakeyaml.Yaml;
 
@@ -54,6 +56,9 @@ public class ConductorConfig {
     private String appActivity;
     private String appWaitActivity;
     private String intentCategory;
+
+    // SauceLabs Authentication
+    private SauceOnDemandAuthentication authentication;
 
     public ConductorConfig() {
         this(DEFAULT_CONFIG_FILE);
@@ -442,5 +447,19 @@ public class ConductorConfig {
 
     private void putCustomCapabilities(Map<String, Object> customCapabilities) {
         this.customCapabilities.putAll(customCapabilities);
+    }
+
+    public SauceOnDemandAuthentication getAuthentication() {
+        String sauceUserName = System.getProperty("SAUCE_USERNAME");
+        String sauceAccessKey = System.getProperty("SAUCE_ACCESS_KEY");
+
+        if (sauceUserName == null) {
+            throw new InvalidArgumentException("Env var for SAUCE_USERNAME cannot be null");
+        }
+        if (sauceAccessKey == null) {
+            throw new InvalidArgumentException("Env var for SAUCE_ACCESS_KEY cannot be null");
+        }
+
+        return new SauceOnDemandAuthentication(sauceUserName, sauceAccessKey);
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -462,10 +462,10 @@ public class ConductorConfig {
     public SauceOnDemandAuthentication getSauceAuthentication(String sauceUserName, String sauceAccessKey) {
 
         if (sauceUserName == null) {
-            throw new InvalidArgumentException("Env var for SAUCE_USERNAME cannot be null");
+            throw new InvalidArgumentException("sauceUserName cannot be null");
         }
         if (sauceAccessKey == null) {
-            throw new InvalidArgumentException("Env var for SAUCE_ACCESS_KEY cannot be null");
+            throw new InvalidArgumentException("sauceAccessKey cannot be null");
         }
 
         return new SauceOnDemandAuthentication(sauceUserName, sauceAccessKey);

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -84,7 +84,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return driver.get();
     }
 
-    public void setDriver(AppiumDriver d) {
+    public void setAppiumDriver(AppiumDriver d) {
         driver.set(d);
     }
 
@@ -118,7 +118,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     private void init(ConductorConfig configuration, AppiumDriver driver) {
         this.configuration = configuration;
         if (driver != null) {
-            setDriver(driver);
+            setAppiumDriver(driver);
         } else {
             URL hub = configuration.getHub();
             DesiredCapabilities capabilities = onCapabilitiesCreated(getCapabilities(configuration));
@@ -128,13 +128,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
             switch (configuration.getPlatformName()) {
                 case ANDROID:
-                    setDriver(hub == null
+                    setAppiumDriver(hub == null
                             ? new AndroidDriver(builder, capabilities)
                             : new AndroidDriver(hub, capabilities));
 
                     break;
                 case IOS:
-                    setDriver(hub == null
+                    setAppiumDriver(hub == null
                             ? new IOSDriver(builder, capabilities)
                             : new IOSDriver(hub, capabilities));
                     break;
@@ -192,6 +192,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         capabilities.setCapability(AndroidMobileCapabilityType.APP_ACTIVITY, config.getAppActivity());
         capabilities.setCapability(AndroidMobileCapabilityType.APP_WAIT_ACTIVITY, config.getAppWaitActivity());
         capabilities.setCapability(AndroidMobileCapabilityType.INTENT_CATEGORY, config.getIntentCategory());
+        capabilities.setCapability("sauceUserName", config.getSauceUserName());
+        capabilities.setCapability("sauceAccessKey", config.getSauceAccessKey());
 
         if (StringUtils.isNotEmpty(config.getAutomationName())) {
             capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, config.getAutomationName());
@@ -912,6 +914,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @Override
     public SauceOnDemandAuthentication getAuthentication() {
-        return configuration.getAuthentication();
+        return configuration.getSauceAuthentication(configuration.getSauceUserName(), configuration.getSauceAccessKey());
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -26,7 +26,6 @@ import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -81,7 +80,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         init(configuration, driver);
     }
 
-    public AppiumDriver getDriver() {
+    public AppiumDriver getAppiumDriver() {
         return driver.get();
     }
 
@@ -109,7 +108,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @AfterMethod(alwaysRun = true)
     public void quit() {
-        getDriver().quit();
+        getAppiumDriver().quit();
     }
 
     private void init(ConductorConfig testConfig) {
@@ -145,7 +144,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
 
         // Set session ID after driver has been initialized
-        String id = getDriver().getSessionId().toString();
+        String id = getAppiumDriver().getSessionId().toString();
         sessionId.set(id);
 
         // TODO: Added to support biometrics on android until java-client PR #473 is pulled in
@@ -222,7 +221,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             Logger.info("WaitForElement: Eat exception thrown waiting for condition");
         }
 
-        int size = getDriver().findElements(by).size();
+        int size = getAppiumDriver().findElements(by).size();
 
         if (size == 0) {
             int attempts = 1;
@@ -234,7 +233,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                     Logger.error(x);
                 }
 
-                size = getDriver().findElements(by).size();
+                size = getAppiumDriver().findElements(by).size();
                 if (size > 0) {
                     break;
                 }
@@ -251,7 +250,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             Logger.error("WARN: There are more than 1 " + by.toString() + " 's!");
         }
 
-        return getDriver().findElement(by);
+        return getAppiumDriver().findElement(by);
     }
 
 
@@ -287,7 +286,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public boolean isPresent(By by) {
-        return getDriver().findElements(by).size() > 0;
+        return getAppiumDriver().findElements(by).size() > 0;
     }
 
     public boolean isPresentWait(String id) {
@@ -329,7 +328,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             Logger.error(newLine + newLine + "----     WARNING: ELEMENT NOT PRESENT  ---- " + newLine + e.toString() + newLine + newLine);
         }
 
-        int size = getDriver().findElements(by).size();
+        int size = getAppiumDriver().findElements(by).size();
 
         if (size == 0) {
             int attempts = 1;
@@ -340,7 +339,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                     Assertions.fail(x.getMessage(), x);
                 }
 
-                size = getDriver().findElements(by).size();
+                size = getAppiumDriver().findElements(by).size();
                 if (size > 0) {
                     break;
                 }
@@ -473,7 +472,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     public Locomotive hideKeyboard() {
         try {
-            getDriver().hideKeyboard();
+            getAppiumDriver().hideKeyboard();
         } catch (WebDriverException e) {
             Logger.error("WARN:" + e.getMessage());
         }
@@ -490,7 +489,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             from = getCenter(/*element=*/null);
         }
 
-        Dimension screen = getDriver().manage().window().getSize();
+        Dimension screen = getAppiumDriver().manage().window().getSize();
         Point to = null;
         if (direction != null) {
             switch (direction) {
@@ -527,14 +526,14 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
-        TouchAction swipe = new TouchAction(getDriver()).press(from.getX(), from.getY())
+        TouchAction swipe = new TouchAction(getAppiumDriver()).press(from.getX(), from.getY())
                 .waitAction(Duration.ofMillis(SWIPE_DURATION_MILLIS)).moveTo(to.getX(), to.getY()).release();
         swipe.perform();
         return this;
     }
   
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
-        Dimension screen = getDriver().manage().window().getSize();
+        Dimension screen = getAppiumDriver().manage().window().getSize();
 
          final int SCREEN_MARGIN = 10;
 
@@ -597,7 +596,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
-        new TouchAction(getDriver()).press(from.getX(), from.getY())
+        new TouchAction(getAppiumDriver()).press(from.getX(), from.getY())
                 .waitAction(Duration.ofMillis(duration))
                 .moveTo(to.getX(), to.getY())
                 .release()
@@ -610,7 +609,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         for (int i = 0; i < attempts; i++) {
             swipeCenterLong(direction);
             try {
-                element = getDriver().findElement(by);
+                element = getAppiumDriver().findElement(by);
                 // element was found, check for visibility
                 if (element.isDisplayed()) {
                     // element is in view, exit the loop
@@ -653,8 +652,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public Point getCenter(WebElement element) {
         int x, y;
         if (element == null) {
-            x = getDriver().manage().window().getSize().getWidth() / 2;
-            y = getDriver().manage().window().getSize().getHeight() / 2;
+            x = getAppiumDriver().manage().window().getSize().getWidth() / 2;
+            y = getAppiumDriver().manage().window().getSize().getHeight() / 2;
         } else {
             x = element.getLocation().getX() + (element.getSize().getWidth() / 2);
             y = element.getLocation().getY() + (element.getSize().getHeight() / 2);
@@ -668,7 +667,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     public List<WebElement> getElements(By by) {
         waitForElement(by);
-        return getDriver().findElements(by);
+        return getAppiumDriver().findElements(by);
     }
 
     /**
@@ -754,12 +753,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateTextPresent(String text) {
-        Assert.assertTrue(getDriver().getPageSource().contains(text));
+        Assert.assertTrue(getAppiumDriver().getPageSource().contains(text));
         return this;
     }
 
     public Locomotive validateTextNotPresent(String text) {
-        Assert.assertFalse(getDriver().getPageSource().contains(text));
+        Assert.assertFalse(getAppiumDriver().getPageSource().contains(text));
         return this;
     }
 
@@ -860,11 +859,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                 // TODO: Restructure when the Java-client supports biometrics (PR #473 on appium/java-client)
                 Map.Entry<String, Map<String, ?>> paramMap = new AbstractMap.SimpleEntry<>("fingerPrint",
                         MobileCommand.prepareArguments("fingerprintId", id));
-                CommandExecutionHelper.execute(getDriver(), paramMap);
+                CommandExecutionHelper.execute(getAppiumDriver(), paramMap);
                 break;
 
             case IOS:
-                PerformsTouchID performsTouchID = (PerformsTouchID) getDriver();
+                PerformsTouchID performsTouchID = (PerformsTouchID) getAppiumDriver();
                 performsTouchID.performTouchID(match);
                 break;
 
@@ -897,7 +896,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive waitForCondition(ExpectedCondition<?> condition, long timeOutInSeconds, long sleepInMillis) {
-        WebDriverWait wait = new WebDriverWait(getDriver(), timeOutInSeconds, sleepInMillis);
+        WebDriverWait wait = new WebDriverWait(getAppiumDriver(), timeOutInSeconds, sleepInMillis);
         wait.until(condition);
         return this;
     }

--- a/src/main/java/com/joss/conductor/mobile/util/ScreenShotUtil.java
+++ b/src/main/java/com/joss/conductor/mobile/util/ScreenShotUtil.java
@@ -18,12 +18,12 @@ public class ScreenShotUtil {
 
     public static void take(Locomotive locomotive, String testName) {
         String artifactName = ArtifactUtil.artifactPathForTest(testName, SCREENSHOT_EXT);
-        writeFile(locomotive.getDriver(), artifactName);
+        writeFile(locomotive.getAppiumDriver(), artifactName);
     }
 
     public static void take(Locomotive locomotive, String path, String testName) {
         String artifactName = ArtifactUtil.artifactPathForTest(path, testName, SCREENSHOT_EXT);
-        writeFile(locomotive.getDriver(), artifactName);
+        writeFile(locomotive.getAppiumDriver(), artifactName);
     }
 
     private static void writeFile(AppiumDriver appiumDriver, String filePathAndName) {

--- a/src/main/java/com/joss/conductor/mobile/util/ScreenShotUtil.java
+++ b/src/main/java/com/joss/conductor/mobile/util/ScreenShotUtil.java
@@ -18,12 +18,12 @@ public class ScreenShotUtil {
 
     public static void take(Locomotive locomotive, String testName) {
         String artifactName = ArtifactUtil.artifactPathForTest(testName, SCREENSHOT_EXT);
-        writeFile(locomotive.driver, artifactName);
+        writeFile(locomotive.getDriver(), artifactName);
     }
 
     public static void take(Locomotive locomotive, String path, String testName) {
         String artifactName = ArtifactUtil.artifactPathForTest(path, testName, SCREENSHOT_EXT);
-        writeFile(locomotive.driver, artifactName);
+        writeFile(locomotive.getDriver(), artifactName);
     }
 
     private static void writeFile(AppiumDriver appiumDriver, String filePathAndName) {

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -9,6 +9,7 @@ import org.assertj.swing.assertions.Assertions;
 import org.mockito.ArgumentCaptor;
 import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.SessionId;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -34,9 +35,11 @@ public class LocomotiveTest {
 
     @BeforeMethod
     public void setup() {
-        mockDriver = mock(AppiumDriver.class);
         androidConfig = new ConductorConfig("/test_yaml/android_full.yaml");
         iosConfig = new ConductorConfig("/test_yaml/ios_full.yaml");
+
+        mockDriver = mock(AppiumDriver.class);
+        when(mockDriver.getSessionId()).thenReturn(new SessionId("123456789"));
     }
 
     @Test


### PR DESCRIPTION
This is to prevent tests from having getDriver().getDriver() to access the core Appium methods.