### PR TITLE
Bugfix for SauceLabs listener assumes remote run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -5,7 +5,6 @@ import com.joss.conductor.mobile.util.PageUtil;
 import com.saucelabs.common.SauceOnDemandAuthentication;
 import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import com.saucelabs.testng.SauceOnDemandAuthenticationProvider;
-import com.saucelabs.testng.SauceOnDemandTestListener;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.MobileCommand;
@@ -45,7 +44,7 @@ import java.util.regex.Pattern;
 /**
  * Created on 8/10/16.
  */
-@Listeners({TestListener.class, SauceOnDemandTestListener.class})
+@Listeners({TestListener.class, SauceLabsListener.class})
 public class Locomotive extends Watchman implements Conductor<Locomotive>, SauceOnDemandSessionIdProvider, SauceOnDemandAuthenticationProvider {
 
     private static final float SWIPE_DISTANCE = 0.25f;
@@ -54,7 +53,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     private static final int SWIPE_DURATION_MILLIS = 2000;
 
     private ThreadLocal<AppiumDriver> driver = new ThreadLocal<>();
-    private ThreadLocal<String> sessionId = new ThreadLocal<String>();
+    private ThreadLocal<String> sessionId = new ThreadLocal<>();
 
     public ConductorConfig configuration;
     private Map<String, String> vars = new HashMap<>();

--- a/src/main/java/com/joss/conductor/mobile/SauceLabsListener.java
+++ b/src/main/java/com/joss/conductor/mobile/SauceLabsListener.java
@@ -1,0 +1,44 @@
+package com.joss.conductor.mobile;
+
+import com.saucelabs.testng.SauceOnDemandTestListener;
+import org.testng.ITestResult;
+
+/**
+ * Adapter for 3rd party listener.
+ */
+public class SauceLabsListener extends SauceOnDemandTestListener {
+
+    private static final String SELENIUM_IS_LOCAL = "SELENIUM_IS_LOCAL";
+    private final boolean local;
+
+    /**
+     * Determine whether the tests are run locally before any other methods are run.
+     *
+     * {@link SauceOnDemandTestListener} assumes by default a remote test is run if {@link #SELENIUM_IS_LOCAL} does not
+     * have a value. For conductor we assume a test run is remote if and only if a hub property is set.
+     */
+    public SauceLabsListener() {
+        final ConductorConfig config = new ConductorConfig();
+        local = config.getHub() != null;
+
+        if (local) {
+            System.setProperty(SELENIUM_IS_LOCAL, "true");
+        } else {
+            System.setProperty(SELENIUM_IS_LOCAL, "");
+        }
+    }
+
+    /**
+     * The default implementation always contacts the sauce labs rest service. For conductor we want to fix this to
+     * happen only for remote tests.
+     *
+     * @param testResult Test result for the test that just passed.
+     */
+    @Override
+    public void onTestSuccess(ITestResult testResult) {
+        if (!local) {
+            super.onTestSuccess(testResult);
+        }
+    }
+
+}


### PR DESCRIPTION
We were seeing NullPointerExceptions for running local tests inside the
Sauce Labs test listener. By wrapping this listener into an adapter we
can overwrite the assumption of any test being remote (on sauce labs)
by default.