### PR TITLE
Hotfix for sending results to sauce labs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -470,4 +470,8 @@ public class ConductorConfig {
 
         return new SauceOnDemandAuthentication(sauceUserName, sauceAccessKey);
     }
+
+    public boolean isLocal() {
+        return getHub() == null;
+    }
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -128,13 +128,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
             switch (configuration.getPlatformName()) {
                 case ANDROID:
-                    setAppiumDriver(hub == null
+                    setAppiumDriver(configuration.isLocal()
                             ? new AndroidDriver(builder, capabilities)
                             : new AndroidDriver(hub, capabilities));
 
                     break;
                 case IOS:
-                    setAppiumDriver(hub == null
+                    setAppiumDriver(configuration.isLocal()
                             ? new IOSDriver(builder, capabilities)
                             : new IOSDriver(hub, capabilities));
                     break;

--- a/src/main/java/com/joss/conductor/mobile/SauceLabsListener.java
+++ b/src/main/java/com/joss/conductor/mobile/SauceLabsListener.java
@@ -9,7 +9,7 @@ import org.testng.ITestResult;
 public class SauceLabsListener extends SauceOnDemandTestListener {
 
     private static final String SELENIUM_IS_LOCAL = "SELENIUM_IS_LOCAL";
-    private final boolean local;
+    private final ConductorConfig config;
 
     /**
      * Determine whether the tests are run locally before any other methods are run.
@@ -18,10 +18,9 @@ public class SauceLabsListener extends SauceOnDemandTestListener {
      * have a value. For conductor we assume a test run is remote if and only if a hub property is set.
      */
     public SauceLabsListener() {
-        final ConductorConfig config = new ConductorConfig();
-        local = config.getHub() != null;
+        config = new ConductorConfig();
 
-        if (local) {
+        if (config.isLocal()) {
             System.setProperty(SELENIUM_IS_LOCAL, "true");
         } else {
             System.setProperty(SELENIUM_IS_LOCAL, "");
@@ -36,7 +35,7 @@ public class SauceLabsListener extends SauceOnDemandTestListener {
      */
     @Override
     public void onTestSuccess(ITestResult testResult) {
-        if (!local) {
+        if (!config.isLocal()) {
             super.onTestSuccess(testResult);
         }
     }

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -28,6 +28,22 @@ public class ConductorConfigTest {
     }
 
     @Test
+    public void config_local()  {
+        ConductorConfig config = new ConductorConfig();
+
+        Assertions.assertThat(config.isLocal())
+                .isTrue();
+    }
+
+    @Test
+    public void config_remote()  {
+        ConductorConfig config = new ConductorConfig("/test_yaml/remote.yaml");
+
+        Assertions.assertThat(config.isLocal())
+                .isFalse();
+    }
+
+    @Test
     public void config_supplied_reads_supplied_config() {
         ConductorConfig config = new ConductorConfig("/test_yaml/simple.yaml");
 

--- a/src/test/resources/test_yaml/remote.yaml
+++ b/src/test/resources/test_yaml/remote.yaml
@@ -1,0 +1,4 @@
+
+platformName: ANDROID
+defaults:
+  hub: https://${SAUCE_USERNAME}:${SAUCE_ACCESS_TOKEN}@ondemand.saucelabs.com:443/wd/hub


### PR DESCRIPTION
The is local check in SauceLabsListener was the opposite of what it
should be. This caused a print of a NullPointerException for local test
runs and not sending results to sauce labs for remote runs.
This hotfix fixes both of those issues and adds a convenience isLocal()
method to ConductorConfig (with unit tests).