### PR TITLE
Conductor now respects setDriver() method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>1.11.3</version>
+    <version>0.11.2</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.11.2</version>
+    <version>0.11.0</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.11.0</version>
+    <version>0.11.2</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.11.0</version>
+    <version>1.11.3</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -1,5 +1,6 @@
 package com.joss.conductor.mobile;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.google.common.base.Strings;
 import com.joss.conductor.mobile.util.PageUtil;
 import com.saucelabs.common.SauceOnDemandAuthentication;
@@ -103,6 +104,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     @AfterMethod(alwaysRun = true)
     public void quit() {
         getAppiumDriver().quit();
+        driver.remove();
     }
 
     private void initialize() {
@@ -515,7 +517,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         // Appium specifies that TouchAction.moveTo should be relative. iOS implements this correctly, but android
         // does not. As a result we have to check if we're on iOS and perform the relativization manually
-        if(configuration.getPlatformName() == Platform.IOS) {
+        if (configuration.getPlatformName() == Platform.IOS) {
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
@@ -524,15 +526,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         swipe.perform();
         return this;
     }
-  
+
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
 
-         final int SCREEN_MARGIN = 10;
+        final int SCREEN_MARGIN = 10;
 
         Point from;
-        if(corner != null) {
-            switch(corner) {
+        if (corner != null) {
+            switch (corner) {
                 case TOP_LEFT:
                     from = new Point(SCREEN_MARGIN, SCREEN_MARGIN);
                     break;
@@ -553,8 +555,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
 
         Point to;
-        if(direction != null) {
-            switch(direction) {
+        if (direction != null) {
+            switch (direction) {
                 case UP:
                     int toYUp = (int) (from.getY() - (screen.getHeight() * percentage));
                     toYUp = toYUp <= 0 ? 1 : toYUp;
@@ -585,7 +587,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         // Appium specifies that TouchAction.moveTo should be relative. iOS implements this correctly, but android
         // does not. As a result we have to check if we're on iOS and perform the relativization manually
-        if(configuration.getPlatformName() == Platform.IOS) {
+        if (configuration.getPlatformName() == Platform.IOS) {
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
@@ -609,7 +611,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                     return element;
                 }
                 // element was not visible, continue scrolling
-            } catch (NoSuchElementException exception) {
+            } catch (WebDriverException exception) {
                 // element could not be found, continue scrolling
             }
         }
@@ -826,7 +828,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                 break;
 
             case IOS:
-                PerformsTouchID performsTouchID = (PerformsTouchID)driver;
+                PerformsTouchID performsTouchID = (PerformsTouchID) driver;
                 performsTouchID.toggleTouchIDEnrollment(true);
                 break;
 
@@ -842,7 +844,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      * fingerprint (Android)
      *
      * @param match Whether or not the finger should match. This parameter is ignored on Android
-     * @param id The id of the enrolled finger. This parameter is ignored on iOS
+     * @param id    The id of the enrolled finger. This parameter is ignored on iOS
      * @return The implementing class for fluency
      */
     public Locomotive performBiometric(boolean match, int id) {
@@ -906,6 +908,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     @Override
     public String getSessionId() {
         return sessionId.get();
+    }
+
+    public Locomotive setSessionId(String seshId) {
+        sessionId.set(seshId);
+        return this;
     }
 
     @Override

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -103,7 +103,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     @AfterMethod(alwaysRun = true)
     public void quit() {
         getAppiumDriver().quit();
-    }
+        driver.remove();
+        }
 
     private void initialize() {
         if (this.configuration == null) {
@@ -609,7 +610,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                     return element;
                 }
                 // element was not visible, continue scrolling
-            } catch (NoSuchElementException exception) {
+            } catch (WebDriverException exception) {
                 // element could not be found, continue scrolling
             }
         }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -1,6 +1,5 @@
 package com.joss.conductor.mobile;
 
-import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.google.common.base.Strings;
 import com.joss.conductor.mobile.util.PageUtil;
 import com.saucelabs.common.SauceOnDemandAuthentication;
@@ -104,7 +103,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     @AfterMethod(alwaysRun = true)
     public void quit() {
         getAppiumDriver().quit();
-        driver.remove();
     }
 
     private void initialize() {
@@ -517,7 +515,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         // Appium specifies that TouchAction.moveTo should be relative. iOS implements this correctly, but android
         // does not. As a result we have to check if we're on iOS and perform the relativization manually
-        if (configuration.getPlatformName() == Platform.IOS) {
+        if(configuration.getPlatformName() == Platform.IOS) {
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
@@ -526,15 +524,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         swipe.perform();
         return this;
     }
-
+  
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
 
-        final int SCREEN_MARGIN = 10;
+         final int SCREEN_MARGIN = 10;
 
         Point from;
-        if (corner != null) {
-            switch (corner) {
+        if(corner != null) {
+            switch(corner) {
                 case TOP_LEFT:
                     from = new Point(SCREEN_MARGIN, SCREEN_MARGIN);
                     break;
@@ -555,8 +553,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
 
         Point to;
-        if (direction != null) {
-            switch (direction) {
+        if(direction != null) {
+            switch(direction) {
                 case UP:
                     int toYUp = (int) (from.getY() - (screen.getHeight() * percentage));
                     toYUp = toYUp <= 0 ? 1 : toYUp;
@@ -587,7 +585,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         // Appium specifies that TouchAction.moveTo should be relative. iOS implements this correctly, but android
         // does not. As a result we have to check if we're on iOS and perform the relativization manually
-        if (configuration.getPlatformName() == Platform.IOS) {
+        if(configuration.getPlatformName() == Platform.IOS) {
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
@@ -611,7 +609,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                     return element;
                 }
                 // element was not visible, continue scrolling
-            } catch (WebDriverException exception) {
+            } catch (NoSuchElementException exception) {
                 // element could not be found, continue scrolling
             }
         }
@@ -828,7 +826,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                 break;
 
             case IOS:
-                PerformsTouchID performsTouchID = (PerformsTouchID) driver;
+                PerformsTouchID performsTouchID = (PerformsTouchID)driver;
                 performsTouchID.toggleTouchIDEnrollment(true);
                 break;
 
@@ -844,7 +842,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      * fingerprint (Android)
      *
      * @param match Whether or not the finger should match. This parameter is ignored on Android
-     * @param id    The id of the enrolled finger. This parameter is ignored on iOS
+     * @param id The id of the enrolled finger. This parameter is ignored on iOS
      * @return The implementing class for fluency
      */
     public Locomotive performBiometric(boolean match, int id) {
@@ -908,11 +906,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     @Override
     public String getSessionId() {
         return sessionId.get();
-    }
-
-    public Locomotive setSessionId(String seshId) {
-        sessionId.set(seshId);
-        return this;
     }
 
     @Override

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -72,37 +72,32 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public Locomotive() {
     }
 
-    /**
-     * Constructor for Unit Tests
-     */
-    public Locomotive(ConductorConfig configuration, AppiumDriver driver) {
-        init(configuration, driver);
-    }
-
     public AppiumDriver getAppiumDriver() {
         return driver.get();
     }
 
-    public void setAppiumDriver(AppiumDriver d) {
+    public Locomotive setAppiumDriver(AppiumDriver d) {
         driver.set(d);
+        return this;
+    }
+
+    public Locomotive setConfiguration(ConductorConfig configuration) {
+        this.configuration = configuration;
+        return this;
     }
 
     @Before
     public void init() {
         // For jUnit get the method name from a test rule.
         this.testMethodName = testNameRule.getMethodName();
-
-        ConductorConfig config = new ConductorConfig();
-        init(config);
+        initialize();
     }
 
     @BeforeMethod(alwaysRun = true)
     public void init(Method method) {
         // For testNG get the method name from an injected dependency.
         this.testMethodName = method.getName();
-
-        ConductorConfig config = new ConductorConfig();
-        init(config);
+        initialize();
     }
 
     @AfterMethod(alwaysRun = true)
@@ -110,15 +105,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         getAppiumDriver().quit();
     }
 
-    private void init(ConductorConfig testConfig) {
-        init(testConfig, null);
-    }
+    private void initialize() {
+        if (this.configuration == null) {
+            this.configuration = new ConductorConfig();
+        }
 
-    private void init(ConductorConfig configuration, AppiumDriver driver) {
-        this.configuration = configuration;
-        if (driver != null) {
-            setAppiumDriver(driver);
-        } else {
+        if (driver.get() == null) {
             URL hub = configuration.getHub();
             DesiredCapabilities capabilities = onCapabilitiesCreated(getCapabilities(configuration));
 

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -62,7 +62,9 @@ public class LocomotiveTest {
         capabilities.setCapability("xcodeOrgId", nul);
         capabilities.setCapability("xcodeSigningId", nul);
         capabilities.setCapability("waitForQuiescence", nul);
-        Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(androidConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.buildCapabilities(androidConfig))
                 .isEqualToComparingFieldByField(capabilities);
@@ -89,7 +91,9 @@ public class LocomotiveTest {
         capabilities.setCapability("xcodeOrgId", "orgId");
         capabilities.setCapability("xcodeSigningId", "signingId");
         capabilities.setCapability("waitForQuiescence", true);
-        Locomotive locomotive = new Locomotive(iosConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(iosConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.buildCapabilities(iosConfig))
                 .isEqualToIgnoringNullFields(capabilities);
@@ -98,7 +102,9 @@ public class LocomotiveTest {
     @Test
     public void test_custom_capabilities() {
         ConductorConfig config = new ConductorConfig("/test_yaml/android_defaults_custom_caps.yaml");
-        Locomotive locomotive = new Locomotive(config, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(config)
+                .setAppiumDriver(mockDriver);
 
         DesiredCapabilities caps = locomotive.buildCapabilities(config);
         Assertions.assertThat(caps.getCapability("foo"))
@@ -119,7 +125,9 @@ public class LocomotiveTest {
 
         when(mockDriver.findElements(id)).thenReturn(Collections.singletonList(foundElement));
         when(mockDriver.findElement(id)).thenReturn(foundElement);
-        Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        Locomotive locomotive = new Locomotive();
+        locomotive.setConfiguration(androidConfig);
+        locomotive.setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.waitForElement(id))
                 .isEqualTo(foundElement);
@@ -135,13 +143,11 @@ public class LocomotiveTest {
 
         final By id = mock(By.class);
         when(mockDriver.findElements(id)).thenReturn(Collections.emptyList());
-        final Locomotive locomotive = new Locomotive(iosConfig, mockDriver);
+        final Locomotive locomotive = new Locomotive()
+                .setConfiguration(iosConfig)
+                .setAppiumDriver(mockDriver);
 
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            public void call() throws Throwable {
-                locomotive.waitForElement(id);
-            }
-        }).isInstanceOf(AssertionError.class);
+        Assertions.assertThatThrownBy(() -> locomotive.waitForElement(id)).isInstanceOf(AssertionError.class);
         // First attempt to find elements plus 5 retries + one added from the driver
         verify(mockDriver, times(numberOfRetries + 2))
                 .findElements(id);
@@ -160,7 +166,9 @@ public class LocomotiveTest {
                 Collections.emptyList(),
                 Collections.singletonList(foundElement));
         when(mockDriver.findElement(id)).thenReturn(foundElement);
-        Locomotive locomotive = new Locomotive(iosConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(iosConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.waitForElement(id))
                 .isEqualTo(foundElement);
@@ -175,7 +183,9 @@ public class LocomotiveTest {
         when(foundElement.isDisplayed()).thenReturn(true);
 
         when(mockDriver.findElements(id)).thenReturn(Collections.singletonList(foundElement));
-        Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(androidConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.isPresentWait(id))
                 .isEqualTo(true);
@@ -191,7 +201,9 @@ public class LocomotiveTest {
 
         final By id = mock(By.class);
         when(mockDriver.findElements(id)).thenReturn(Collections.emptyList());
-        final Locomotive locomotive = new Locomotive(iosConfig, mockDriver);
+        final Locomotive locomotive = new Locomotive()
+                .setConfiguration(iosConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.isPresentWait(id))
                 .isEqualTo(false);
@@ -212,7 +224,9 @@ public class LocomotiveTest {
                 Collections.emptyList(),
                 Collections.singletonList(foundElement));
         when(mockDriver.findElement(id)).thenReturn(foundElement);
-        Locomotive locomotive = new Locomotive(iosConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(iosConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.isPresentWait(id))
                 .isEqualTo(true);
@@ -227,7 +241,9 @@ public class LocomotiveTest {
         when(element.getSize()).thenReturn(new Dimension(10, 10));
 
         Point center = new Point(55, 5);
-        Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(androidConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.getCenter(element))
                 .isEqualToComparingFieldByField(center);
@@ -244,7 +260,9 @@ public class LocomotiveTest {
         when(mockDriver.manage()).thenReturn(options);
 
         Point center = new Point(50, 25);
-        Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        Locomotive locomotive = new Locomotive()
+                .setConfiguration(androidConfig)
+                .setAppiumDriver(mockDriver);
 
         Assertions.assertThat(locomotive.getCenter(/*webElement=*/null))
                 .isEqualToComparingFieldByField(center);
@@ -266,7 +284,7 @@ public class LocomotiveTest {
         Map<String, List<Object>> actualParameters = getTouchActionParameters(actual);
         Map<String, List<Object>> expectedParameters = getTouchActionParameters(expected);
 
-        assertThat((Map<String, List<Object>>)actualParameters, matchesEntriesIn((Map<String, List<Object>>)expectedParameters));
+        assertThat(actualParameters, matchesEntriesIn(expectedParameters));
     }
 
     private void initMockDriverSizes() {
@@ -296,7 +314,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(50, 75), new Point(0, 25) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenter(SwipeElementDirection.DOWN);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -318,7 +338,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(50, 99), new Point(0, 49) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenterLong(SwipeElementDirection.DOWN);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -339,7 +361,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(25, 50), new Point(-25, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenter(SwipeElementDirection.LEFT);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -360,7 +384,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(1, 50), new Point(-49, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenterLong(SwipeElementDirection.LEFT);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -381,7 +407,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(50, 25), new Point(0, -25) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenter(SwipeElementDirection.UP);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -402,7 +430,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(50, 1), new Point(0, -49) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenterLong(SwipeElementDirection.UP);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -423,7 +453,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(75, 50), new Point(25, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenter(SwipeElementDirection.RIGHT);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -444,7 +476,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(99, 50), new Point(49, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCenterLong(SwipeElementDirection.RIGHT);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -461,30 +495,16 @@ public class LocomotiveTest {
     public void test_perform_swipe_none_asserts() {
         initMockDriverSizes();
 
-        final Locomotive locomotive = new Locomotive(androidConfig, mockDriver);
+        final Locomotive locomotive = new Locomotive()
+                .setConfiguration(androidConfig)
+                .setAppiumDriver(mockDriver);
 
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            public void call() throws Throwable {
-                locomotive.swipeCenter(SwipeElementDirection.NONE);
-            }
-        }).isInstanceOf(IllegalArgumentException.class);
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            public void call() throws Throwable {
-                locomotive.swipeCenterLong(SwipeElementDirection.NONE);
-            }
-        }).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> locomotive.swipeCenter(SwipeElementDirection.NONE)).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> locomotive.swipeCenterLong(SwipeElementDirection.NONE)).isInstanceOf(IllegalArgumentException.class);
 
         // Swipe @null
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            public void call() throws Throwable {
-                locomotive.swipeCenter(null);
-            }
-        }).isInstanceOf(IllegalArgumentException.class);
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            public void call() throws Throwable {
-                locomotive.swipeCenterLong(null);
-            }
-        }).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> locomotive.swipeCenter(null)).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> locomotive.swipeCenterLong(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -495,7 +515,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(90, 40), new Point(0, -50) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.BOTTOM_RIGHT, SwipeElementDirection.UP, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -516,7 +538,10 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(90, 1), new Point(0, -89) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
+
             locomotive.swipeCornerSuperLong(ScreenCorner.BOTTOM_RIGHT, SwipeElementDirection.UP, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
             verify(mockDriver, times(i+1))
@@ -536,7 +561,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(10, 40), new Point(0, -50) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.BOTTOM_LEFT, SwipeElementDirection.UP, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -557,7 +584,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(10, 1), new Point(0, -89) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerSuperLong(ScreenCorner.BOTTOM_LEFT, SwipeElementDirection.UP, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -578,7 +607,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(90, 60), new Point(0, 50) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.TOP_RIGHT, SwipeElementDirection.DOWN, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -599,7 +630,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(90, 99), new Point(0, 89) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerSuperLong(ScreenCorner.TOP_RIGHT, SwipeElementDirection.DOWN, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -620,7 +653,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(10, 60), new Point(0, 50) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.TOP_LEFT, SwipeElementDirection.DOWN, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -641,7 +676,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(10, 99), new Point(0, 89) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerSuperLong(ScreenCorner.TOP_LEFT, SwipeElementDirection.DOWN, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -662,7 +699,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(60, 10), new Point(50, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.TOP_LEFT, SwipeElementDirection.RIGHT, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -683,7 +722,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(40, 10), new Point(-50, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeCornerLong(ScreenCorner.TOP_RIGHT, SwipeElementDirection.LEFT, 100);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -705,7 +746,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(5, 30), new Point(0, 25) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipe(SwipeElementDirection.DOWN, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -727,7 +770,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(5, 55), new Point(0, 50) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeLong(SwipeElementDirection.DOWN, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -749,7 +794,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(1, 5), new Point(-4, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipe(SwipeElementDirection.LEFT, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -771,7 +818,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(1, 5), new Point(-4, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeLong(SwipeElementDirection.LEFT, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -793,7 +842,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(5, 1), new Point(0, -4) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipe(SwipeElementDirection.UP, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -815,7 +866,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(5, 1), new Point(0, -4) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeLong(SwipeElementDirection.UP, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -837,7 +890,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(30, 5), new Point(25, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipe(SwipeElementDirection.RIGHT, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);
@@ -859,7 +914,9 @@ public class LocomotiveTest {
         Point[] moveTo = { new Point(55, 5), new Point(50, 0) };
 
         for(int i = 0; i < 2; ++i) {
-            final Locomotive locomotive = new Locomotive(configs[i], mockDriver);
+            final Locomotive locomotive = new Locomotive()
+                    .setConfiguration(configs[i])
+                    .setAppiumDriver(mockDriver);
 
             locomotive.swipeLong(SwipeElementDirection.RIGHT, element);
             ArgumentCaptor<TouchAction> touchCapture = ArgumentCaptor.forClass(TouchAction.class);


### PR DESCRIPTION
Conductor would ignore the setDriver method and try to reinitialize it on every test.
Added a `setConfiguration()` method as well to follow the convention
Updated tests to not use the constructor and use the setters