### PR TITLE
new capabilities for more timeouts and way of changing the way we find elements

### DIFF
--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -66,8 +66,8 @@ public class ConductorConfig {
     private String sauceAccessKey;
 
     // Timeouts
-    private int newCommandTimeout;
-    private int idleTimeout;
+    private String newCommandTimeout;
+    private String idleTimeout;
 
     public ConductorConfig() {
         this(DEFAULT_CONFIG_FILE);
@@ -424,9 +424,9 @@ public class ConductorConfig {
 
     public String getSauceAccessKey() {return this.sauceAccessKey; }
 
-    public int getNewCommandTimeout() {return this.newCommandTimeout;}
+    public String getNewCommandTimeout() {return this.newCommandTimeout;}
 
-    public int getIdleTimeout() {return this.idleTimeout;}
+    public String getIdleTimeout() {return this.idleTimeout;}
 
 
 
@@ -434,9 +434,9 @@ public class ConductorConfig {
 
     public void setSauceAccessKey (String sauceAccessKey) {this.sauceAccessKey = sauceAccessKey; }
 
-    public void setNewCommandTimeout (int newCommandTimeout) {this.newCommandTimeout = newCommandTimeout;}
+    public void setNewCommandTimeout (String newCommandTimeout) {this.newCommandTimeout = newCommandTimeout;}
 
-    public void setIdleTimeout (int idleTimeout) {this.idleTimeout = idleTimeout;}
+    public void setIdleTimeout (String idleTimeout) {this.idleTimeout = idleTimeout;}
 
     public void setSimpleIsVisibleCheck (boolean value) {this.simpleIsVisibleCheck = value;}
 

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -47,6 +47,7 @@ public class ConductorConfig {
     private String automationName;
     private String appPackageName;
     private Map<String, Object> customCapabilities = new HashMap<>();
+    private Boolean simpleIsVisibleCheck;
 
     // iOS specific
     private String xcodeSigningId;
@@ -63,6 +64,10 @@ public class ConductorConfig {
     private SauceOnDemandAuthentication authentication;
     private String sauceUserName;
     private String sauceAccessKey;
+
+    // Timeouts
+    private int newCommandTimeout;
+    private int idleTimeout;
 
     public ConductorConfig() {
         this(DEFAULT_CONFIG_FILE);
@@ -408,17 +413,32 @@ public class ConductorConfig {
         return waitForQuiescence;
     }
 
+    public Boolean isSimpleIsVisibleCheck() { return simpleIsVisibleCheck;}
+
     public void setWaitForQuiescence(boolean waitForQuiescence) {
         this.waitForQuiescence = waitForQuiescence;
     }
+
 
     public String getSauceUserName() {return this.sauceUserName; }
 
     public String getSauceAccessKey() {return this.sauceAccessKey; }
 
+    public int getNewCommandTimeout() {return this.newCommandTimeout;}
+
+    public int getIdleTimeout() {return this.idleTimeout;}
+
+
+
     public void setSauceUserName (String sauceUserName) {this.sauceUserName = sauceUserName; }
 
     public void setSauceAccessKey (String sauceAccessKey) {this.sauceAccessKey = sauceAccessKey; }
+
+    public void setNewCommandTimeout (int newCommandTimeout) {this.newCommandTimeout = newCommandTimeout;}
+
+    public void setIdleTimeout (int idleTimeout) {this.idleTimeout = idleTimeout;}
+
+    public void setSimpleIsVisibleCheck (boolean value) {this.simpleIsVisibleCheck = value;}
 
     public Platform getPlatformName() {
         return platformName;

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -186,6 +186,9 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         capabilities.setCapability("sauceUserName", config.getSauceUserName());
         capabilities.setCapability("sauceAccessKey", config.getSauceAccessKey());
         capabilities.setCapability("waitForQuiescence", config.isWaitForQuiescence());
+        capabilities.setCapability("newCommandTimeout", config.getNewCommandTimeout());
+        capabilities.setCapability("idleTimeout", config.getIdleTimeout());
+        capabilities.setCapability("simpleIsVisibleCheck", config.isSimpleIsVisibleCheck());
 
         if (StringUtils.isNotEmpty(config.getAutomationName())) {
             capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, config.getAutomationName());

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -532,7 +532,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
 
-         final int SCREEN_MARGIN = 10;
+         final int SCREEN_MARGIN = 30;
 
         Point from;
         if(corner != null) {

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -532,7 +532,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
 
-         final int SCREEN_MARGIN = 30;
+         final int SCREEN_MARGIN = 130;
 
         Point from;
         if(corner != null) {

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -186,7 +186,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         capabilities.setCapability("sauceUserName", config.getSauceUserName());
         capabilities.setCapability("sauceAccessKey", config.getSauceAccessKey());
         capabilities.setCapability("waitForQuiescence", config.isWaitForQuiescence());
-        capabilities.setCapability("newCommandTimeout", config.getNewCommandTimeout());
+        capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, config.getNewCommandTimeout());
         capabilities.setCapability("idleTimeout", config.getIdleTimeout());
         capabilities.setCapability("simpleIsVisibleCheck", config.isSimpleIsVisibleCheck());
 

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -532,7 +532,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
 
-         final int SCREEN_MARGIN = 130;
+        final int SCREEN_MARGIN = 10;
 
         Point from;
         if(corner != null) {

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -1,6 +1,7 @@
 package com.joss.conductor.mobile;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -84,6 +85,9 @@ public class ConductorConfigTest {
                 .isEqualTo("./apps/android.apk");
         Assertions.assertThat(config.getAppActivity())
                 .isEqualTo("com.android.activity");
+
+        Assertions.assertThat(config.getNewCommandTimeout() == null);
+        Assertions.assertThat(config.getIdleTimeout() == null);
     }
 
     @Test
@@ -100,6 +104,9 @@ public class ConductorConfigTest {
                 .isEqualTo("iPhone Developer");
         Assertions.assertThat(config.getXcodeOrgId())
                 .isEqualTo(("TEAMID"));
+
+        Assertions.assertThat(config.getNewCommandTimeout() == null);
+        Assertions.assertThat(config.getIdleTimeout() == null);
     }
 
     @Test

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -62,6 +62,10 @@ public class LocomotiveTest {
         capabilities.setCapability("xcodeOrgId", nul);
         capabilities.setCapability("xcodeSigningId", nul);
         capabilities.setCapability("waitForQuiescence", nul);
+        capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, "600");
+        capabilities.setCapability("idleTimeout", "600");
+        capabilities.setCapability("simpleIsVisibleCheck", true);
+
         Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
                 .setAppiumDriver(mockDriver);
@@ -91,6 +95,9 @@ public class LocomotiveTest {
         capabilities.setCapability("xcodeOrgId", "orgId");
         capabilities.setCapability("xcodeSigningId", "signingId");
         capabilities.setCapability("waitForQuiescence", true);
+        capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, "600");
+        capabilities.setCapability("idleTimeout", "600");
+        capabilities.setCapability("simpleIsVisibleCheck", true);
         Locomotive locomotive = new Locomotive()
                 .setConfiguration(iosConfig)
                 .setAppiumDriver(mockDriver);

--- a/src/test/resources/test_yaml/android_full.yaml
+++ b/src/test/resources/test_yaml/android_full.yaml
@@ -6,6 +6,7 @@ defaults:
   noReset: false
   orientation: vertical
 
+
   android:
     appFile: /full/path/to/android.apk
     udid: qwerty
@@ -16,3 +17,9 @@ defaults:
     appActivity: LaunchActivity
     appWaitActivity: HomeActivity
     intentCategory: android.intent.category.LEANBACK_LAUNCHER
+    newCommandTimeout: 600
+    idleTimeout: 600
+    simpleIsVisibleCheck: true
+
+
+

--- a/src/test/resources/test_yaml/ios_full.yaml
+++ b/src/test/resources/test_yaml/ios_full.yaml
@@ -16,3 +16,6 @@ defaults:
     xcodeSigningId: signingId
     waitForQuiescence: true
     appFile: /full/path/to/ios.ipa
+    newCommandTimeout: 600
+    idleTimeout: 600
+    simpleIsVisibleCheck: true


### PR DESCRIPTION
NewCommand timeout
idleTimeout

We found a bug/feature in Appium that was making it hard to find an element so for some of our tests we need to add change this with the new cap. of simpleIsVisibleCheck (Appium has more "smart" logic to help with web element validations which we don't need)