### PR TITLE
feature: config environment variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.14.0</version>
+    <version>0.15.0</version>
 
     <repositories>
         <repository>

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -228,12 +228,35 @@ public class ConductorConfigTest {
     }
 
     @Test
-    public void environment_variables_complete_by_environment() {
+    public void environment_variables_complete_by_systen() {
         System.setProperty("FOO_PROPERTY", "foobar");
         ConductorConfig config = new ConductorConfig("/test_yaml/environment_vars.yaml");
 
         Assertions.assertThat(config.getUdid())
                 .isEqualTo("foobar");
+        System.clearProperty("FOO_PROPERTY");
+    }
+
+    @Test
+    public void environment_variables_complete_by_environment() {
+        Map<String, String> environmentVariables = new HashMap<>();
+        environmentVariables.put("FOO_PROPERTY", "foobar_env");
+        ConductorConfig config = new ConductorConfig("/test_yaml/environment_vars.yaml", environmentVariables);
+
+        Assertions.assertThat(config.getUdid())
+                .isEqualTo("foobar_env");
+    }
+
+    @Test
+    public void environment_variables_system_overwrites_environment() {
+        Map<String, String> environmentVariables = new HashMap<>();
+        environmentVariables.put("FOO_PROPERTY", "foobar_env");
+        System.setProperty("FOO_PROPERTY", "foobar_system");
+
+        ConductorConfig config = new ConductorConfig("/test_yaml/environment_vars.yaml", environmentVariables);
+
+        Assertions.assertThat(config.getUdid())
+                .isEqualTo("foobar_system");
         System.clearProperty("FOO_PROPERTY");
     }
 


### PR DESCRIPTION
Currently the only way to substitute $FOO values in the config.yaml is to start
the test with system properties '-DFOO=bar'. This change enables the config to also
read the value from an environment variable 'export FOO=bar' if no system property
is provided

Changes:
1. config value substitution is read from environment of no system value is found
2. ConductorConfig has an addtional parameter in the testing constructor to allow
a custom set of environment variables for unit testing (mock the environment)
3. ConductorConfig does not catch all exception in init() anymore to allow for a
fast crash if the config is not setup correctly