### PR TITLE
Send appium version capability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -199,6 +199,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, config.getNewCommandTimeout());
         capabilities.setCapability("idleTimeout", config.getIdleTimeout());
         capabilities.setCapability("simpleIsVisibleCheck", config.isSimpleIsVisibleCheck());
+        capabilities.setCapability(MobileCapabilityType.APPIUM_VERSION, config.getAppiumVersion());
 
         if (StringUtils.isNotEmpty(config.getAutomationName())) {
             capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, config.getAutomationName());

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -272,4 +272,11 @@ public class ConductorConfigTest {
         System.clearProperty("PLATFORM_MAJOR");
         System.clearProperty("PLATFORM_MINOR");
     }
+
+    @Test
+    public void appium_version_is_read() {
+        ConductorConfig config = new ConductorConfig("/test_yaml/all_platforms.yaml");
+
+        Assertions.assertThat(config.getAppiumVersion()).isEqualTo("1.7.1");
+    }
 }

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -73,6 +73,7 @@ public class LocomotiveTest {
         capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, "600");
         capabilities.setCapability("idleTimeout", "600");
         capabilities.setCapability("simpleIsVisibleCheck", true);
+        capabilities.setCapability(MobileCapabilityType.APPIUM_VERSION, "1.7.1");
 
         Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)

--- a/src/test/resources/test_yaml/android_full.yaml
+++ b/src/test/resources/test_yaml/android_full.yaml
@@ -5,6 +5,7 @@ defaults:
   fullReset: true
   noReset: false
   orientation: vertical
+  appiumVersion: 1.7.1
 
 
   android:


### PR DESCRIPTION
SauceLabs uses a default appium version if no specific version is being
sent as a capability. This change allows us to send the version which
is specified in the config.yaml.