### PR TITLE
 start session retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -69,6 +69,7 @@ public class ConductorConfig {
     // Timeouts
     private String newCommandTimeout;
     private String idleTimeout;
+    private int    startSessionRetries = 1; // by default try only once
 
     // dependencies
     private Map<String, String> environment;
@@ -555,5 +556,13 @@ public class ConductorConfig {
     }
     public boolean isHubLocal() {
         return islocalhub;
+    }
+
+    public int getStartSessionRetries() {
+        return startSessionRetries;
+    }
+
+    public void setStartSessionRetries(int startSessionRetries) {
+        this.startSessionRetries = startSessionRetries;
     }
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -144,13 +144,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             switch (configuration.getPlatformName()) {
                 case ANDROID:
                     setAppiumDriver(configuration.isLocal()
-                                            ? new AndroidDriver(builder, capabilities)
-                                            : new AndroidDriver(hub, capabilities));
+                            ? new AndroidDriver(builder, capabilities)
+                            : new AndroidDriver(hub, capabilities));
                     break;
                 case IOS:
                     setAppiumDriver(configuration.isLocal()
-                                            ? new IOSDriver(builder, capabilities)
-                                            : new IOSDriver(hub, capabilities));
+                            ? new IOSDriver(builder, capabilities)
+                            : new IOSDriver(hub, capabilities));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown platform: " + configuration.getPlatformName());

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -156,13 +156,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             switch (configuration.getPlatformName()) {
                 case ANDROID:
                     setAppiumDriver(configuration.isLocal()
-                                            ? new AndroidDriver(builder, capabilities)
-                                            : new AndroidDriver(hub, capabilities));
+                            ? new AndroidDriver(builder, capabilities)
+                            : new AndroidDriver(hub, capabilities));
                     break;
                 case IOS:
                     setAppiumDriver(configuration.isLocal()
-                                            ? new IOSDriver(builder, capabilities)
-                                            : new IOSDriver(hub, capabilities));
+                            ? new IOSDriver(builder, capabilities)
+                            : new IOSDriver(hub, capabilities));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown platform: " + configuration.getPlatformName());

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -279,4 +279,19 @@ public class ConductorConfigTest {
 
         Assertions.assertThat(config.getAppiumVersion()).isEqualTo("1.7.1");
     }
+
+    @Test
+    public void start_session_retries_default() {
+        ConductorConfig config = new ConductorConfig("/test_yaml/all_platforms.yaml");
+
+        Assertions.assertThat(config.getStartSessionRetries()).isEqualTo(1);
+    }
+
+    @Test
+    public void start_session_retries_from_file() {
+        ConductorConfig config = new ConductorConfig("/test_yaml/android_full.yaml");
+
+        Assertions.assertThat(config.getStartSessionRetries()).isEqualTo(6);
+    }
+
 }

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -363,7 +363,7 @@ public class LocomotiveTest {
                 .setAppiumDriver(customDriver);
 
         try {
-            locomotive.startAppiumSession();
+            locomotive.startAppiumSession(1);
             assertThat("Expected startAppiumSession() has failed", false);
         } catch (WebDriverException e) {
             assertThat("Verify startAppiumSession() has failed", true);

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;
@@ -345,6 +346,31 @@ public class LocomotiveTest {
                             .release());
         }
 
+    }
+
+    @Test
+    public void startAppiumSessionCounter() {
+        AppiumDriver customDriver = mock(AppiumDriver.class);
+        // cause startAppiumSession() to fail
+        when(customDriver.getSessionId()).thenReturn(null);
+
+        ConductorConfig customConfig = new ConductorConfig("/test_yaml/android_full.yaml");
+        // cause startAppiumSession to retry 4 times
+        customConfig.setStartSessionRetries(4);
+
+        final Locomotive locomotive = new Locomotive()
+                .setConfiguration(customConfig)
+                .setAppiumDriver(customDriver);
+
+        try {
+            locomotive.startAppiumSession();
+            assertThat("Expected startAppiumSession() has failed", false);
+        } catch (WebDriverException e) {
+            assertThat("Verify startAppiumSession() has failed", true);
+        }
+
+        // expected 4 retries, verified by making sure the sessionId was checked 4 times.
+        verify(customDriver, times(4)).getSessionId();
     }
 
     @Test

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -4,8 +4,10 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.TouchAction;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.assertj.swing.assertions.Assertions;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
@@ -59,7 +61,7 @@ public class LocomotiveTest {
         capabilities.setCapability(MobileCapabilityType.UDID, "qwerty");
         capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, "Pixelated Nexus");
         capabilities.setCapability(MobileCapabilityType.APP, "/full/path/to/android.apk");
-        capabilities.setCapability(MobileCapabilityType.ORIENTATION, "vertical");
+        capabilities.setCapability(MobileCapabilityType.ORIENTATION, "PORTRAIT");
         capabilities.setCapability("autoGrantPermissions", true);
         capabilities.setCapability(MobileCapabilityType.NO_RESET, false);
         capabilities.setCapability(MobileCapabilityType.FULL_RESET, true);
@@ -350,18 +352,17 @@ public class LocomotiveTest {
 
     @Test
     public void startAppiumSessionCounter() {
-        AppiumDriver customDriver = mock(AppiumDriver.class);
-        // cause startAppiumSession() to fail
-        when(customDriver.getSessionId()).thenReturn(null);
-
         ConductorConfig customConfig = new ConductorConfig("/test_yaml/android_full.yaml");
         // cause startAppiumSession to retry 4 times
         customConfig.setStartSessionRetries(4);
 
-        final Locomotive locomotive = new Locomotive()
-                .setConfiguration(customConfig)
-                .setAppiumDriver(customDriver);
+        // spy on the config to count invocations
+        ConductorConfig spy = Mockito.spy(customConfig);
 
+        final Locomotive locomotive = new Locomotive()
+                .setConfiguration(spy);
+
+        // run the method under test
         try {
             locomotive.startAppiumSession(1);
             assertThat("Expected startAppiumSession() has failed", false);
@@ -369,8 +370,8 @@ public class LocomotiveTest {
             assertThat("Verify startAppiumSession() has failed", true);
         }
 
-        // expected 4 retries, verified by making sure the sessionId was checked 4 times.
-        verify(customDriver, times(4)).getSessionId();
+        // expected 4 retries, verified by making sure the spy has been called 4 times.
+        verify(spy, times(4)).isLocal();
     }
 
     @Test

--- a/src/test/resources/test_yaml/android_full.yaml
+++ b/src/test/resources/test_yaml/android_full.yaml
@@ -4,7 +4,7 @@ platformName: ANDROID
 defaults:
   fullReset: true
   noReset: false
-  orientation: vertical
+  orientation: PORTRAIT
   appiumVersion: 1.7.1
   startSessionRetries: 6
 

--- a/src/test/resources/test_yaml/android_full.yaml
+++ b/src/test/resources/test_yaml/android_full.yaml
@@ -6,6 +6,7 @@ defaults:
   noReset: false
   orientation: vertical
   appiumVersion: 1.7.1
+  startSessionRetries: 6
 
 
   android:


### PR DESCRIPTION
Running tests remotely can sometimes cause the sessions to not be
created correctly. I suspect this is due to network problems.

This feature allows to retry starting the session if it fails.
The maximum amount of retries can be set in the config with the
value 'startSessionRetries' which defaults to '1'.