### PR TITLE
bugfix/quit method catch (#96)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.willowtreeapps</groupId>
     <artifactId>conductor-mobile</artifactId>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -34,6 +34,7 @@ import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.pmw.tinylog.LogEntry;
 import org.pmw.tinylog.Logger;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -113,9 +114,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @AfterMethod(alwaysRun = true)
     public void quit() {
-        getAppiumDriver().quit();
-        driver.remove();
+        try {
+            getAppiumDriver().quit();
+            driver.remove();
+        } catch (org.openqa.selenium.WebDriverException exception) {
+            Logger.warn("WebDriverException occurred during quit method", exception);
         }
+    }
 
     private void initialize() {
         if (this.configuration == null) {


### PR DESCRIPTION
Tests that are run in Sauce Labs can sometimes fail due to a 504 time-out exception.

This bug fix will handle the exception, allowing the test suite to pass with an error thrown instead of failing in the case of a time-out.