### PR TITLE
Add More Swipe Options, refactor waitForElement, rename config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Conductor Mobile is a port of the [Conductor](https://github.com/conductor-frame
     <dependency>
         <groupId>com.willowtreeapps</groupId>
         <artifactId>conductor-mobile</artifactId>
-        <version>0.19.0</version>
+        <version>0.19.1</version>
     </dependency>
 </dependencies>
 ```
@@ -38,8 +38,8 @@ The general configuration only has two properties: `platformName` (which must be
 The defaults section contains both general defaults and defaults per platform. It looks like this:
 ```yaml
 defaults:
-  retries: 3
-  timeout: 10
+  implicitWaitTime: 3
+  appiumRequestTimeout: 10
   screenshotOnFail: false
   autoGrantPermissions: true
 
@@ -48,7 +48,7 @@ defaults:
     deviceName: iPhone 8
 
   android:
-    timeout: 15
+    appiumRequestTimeout: 15
     platformVersion: 8.0
 ```
 Platforms can override defaults just be re-specifying them in the platform section
@@ -68,8 +68,8 @@ ios_sauce_labs:
   deviceName: iPhone 8
 
 shorter_timeouts:
-  timeout: 1
-  retries: 2
+  appiumRequestTimeout: 1
+  implicitWaitTime: 2
 ```
 You can see a variety of example configuration files in the unit tests for conductor [here](src/test/resources/test_yaml)
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.willowtreeapps'
-version = '0.19.0'
+version = '0.19.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/joss/conductor/mobile/Conductor.java
+++ b/src/main/java/com/joss/conductor/mobile/Conductor.java
@@ -77,6 +77,9 @@ public interface Conductor<Test> {
      * @return The implementing class for fluency
      */
     Test swipeCenter(SwipeElementDirection direction);
+    Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis);
+    Test swipeCenter(SwipeElementDirection direction, short numberOfSwipes);
+    Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes);
 
     /**
      * Swipe on specified direction from center 50 percent of the screen
@@ -84,6 +87,9 @@ public interface Conductor<Test> {
      * @return The implementing class for fluency
      */
     Test swipeCenterLong(SwipeElementDirection direction);
+    Test swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis);
+    Test swipeCenterLong(SwipeElementDirection direction, short numberOfSwipes);
+    Test swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes);
 
 
     Test swipeCornerLong(ScreenCorner corner, SwipeElementDirection direction, int duration);
@@ -98,6 +104,9 @@ public interface Conductor<Test> {
     Test swipe(SwipeElementDirection direction, String id);
     Test swipe(SwipeElementDirection direction, By by);
     Test swipe(SwipeElementDirection direction, WebElement element);
+    Test swipe(SwipeElementDirection direction, String id, int swipeDurationInMillis);
+    Test swipe(SwipeElementDirection direction, By by, int swipeDurationInMillis);
+    Test swipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis);
 
     /**
      * Swipe on specified direction from element 50 percent of the screen

--- a/src/main/java/com/joss/conductor/mobile/Conductor.java
+++ b/src/main/java/com/joss/conductor/mobile/Conductor.java
@@ -78,7 +78,7 @@ public interface Conductor<Test> {
      */
     Test swipeCenter(SwipeElementDirection direction);
     Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis);
-    Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes);
+    Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes);
 
     /**
      * Swipe on specified direction from center 50 percent of the screen
@@ -87,8 +87,7 @@ public interface Conductor<Test> {
      */
     Test swipeCenterLong(SwipeElementDirection direction);
     Test swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis);
-    Test swipeCenterLong(SwipeElementDirection direction, short numberOfSwipes);
-    Test swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes);
+    Test swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes);
 
 
     Test swipeCornerLong(ScreenCorner corner, SwipeElementDirection direction, int duration);

--- a/src/main/java/com/joss/conductor/mobile/Conductor.java
+++ b/src/main/java/com/joss/conductor/mobile/Conductor.java
@@ -78,7 +78,6 @@ public interface Conductor<Test> {
      */
     Test swipeCenter(SwipeElementDirection direction);
     Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis);
-    Test swipeCenter(SwipeElementDirection direction, short numberOfSwipes);
     Test swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes);
 
     /**

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -26,7 +26,17 @@ public class ConductorConfig {
 
     // Conductor properties
     private String[] currentSchemes;
+    /***
+     * @deprecated in favor of {@link #appiumRequestTimeout} for clarity sake on what the variable actually is used for
+     */
+    @Deprecated(since = "0.19.1")
+    private int timeout = 5; // deprecated in favor of `appiumRequestTimeout`
     private int appiumRequestTimeout = 5;
+    /***
+     * @deprecated in favor of {@link #implicitWaitTime} for clarity sake on what the variable actually is used for
+     */
+    @Deprecated(since = "0.19.1")
+    private int retries = 5; // deprecated in favor of `implicitWaitTime`
     private int implicitWaitTime = 5;
     private boolean screenshotOnFail = true;
     private boolean screenshotOnSkip = false;
@@ -248,16 +258,58 @@ public class ConductorConfig {
         this.appiumVersion = appiumVersion;
     }
 
+    /***
+     * Returns the {@link #timeout} variable, which has been deprecated in favor of {@link #appiumRequestTimeout} for clarity
+     *
+     * @deprecated use {@link #getAppiumRequestTimeout()} instead
+     */
+    @Deprecated(since = "0.19.1")
+    public int getTimeout() {
+        return timeout;
+    }
+
     public int getAppiumRequestTimeout() {
         return appiumRequestTimeout;
+    }
+
+    /***
+     * Sets the {@link #timeout} variable, which has been deprecated in favor of {@link #appiumRequestTimeout} for clarity
+     * Consider replacing the `timeout:` options in the config yaml with `appiumRequestTimeout`
+     *
+     * @deprecated use {@link #setAppiumRequestTimeout(int)} instead
+     */
+    @Deprecated(since = "0.19.1")
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 
     public void setAppiumRequestTimeout(int appiumRequestTimeout) {
         this.appiumRequestTimeout = appiumRequestTimeout;
     }
 
+    /***
+     * Returns the {@link #retries} variable, which has been deprecated in favor of {@link #implicitWaitTime} for clarity
+     *
+     * @deprecated use {@link #getImplicitWaitTime()} instead
+     */
+    @Deprecated(since = "0.19.1")
+    public int getRetries() {
+        return retries;
+    }
+
     public int getImplicitWaitTime() {
         return implicitWaitTime;
+    }
+
+    /***
+     * Sets the {@link #retries} variable, which has been deprecated in favor of {@link #implicitWaitTime} for clarity
+     * Consider replacing the `retries:` options in the config yaml with `implicitWaitTime`
+     *
+     * @deprecated use {@link #setImplicitWaitTime(int)}  instead
+     */
+    @Deprecated(since = "0.19.1")
+    public void setRetries(int retries) {
+        this.retries = retries;
     }
 
     public void setImplicitWaitTime(int implicitWaitTime) {

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -29,13 +29,13 @@ public class ConductorConfig {
     /***
      * @deprecated in favor of {@link #appiumRequestTimeout} for clarity sake on what the variable actually is used for
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     private int timeout = 5; // deprecated in favor of `appiumRequestTimeout`
     private int appiumRequestTimeout = 5;
     /***
      * @deprecated in favor of {@link #implicitWaitTime} for clarity sake on what the variable actually is used for
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     private int retries = 5; // deprecated in favor of `implicitWaitTime`
     private int implicitWaitTime = 5;
     private boolean screenshotOnFail = true;
@@ -263,7 +263,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #getAppiumRequestTimeout()} instead
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     public int getTimeout() {
         return timeout;
     }
@@ -278,7 +278,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #setAppiumRequestTimeout(int)} instead
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }
@@ -292,7 +292,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #getImplicitWaitTime()} instead
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     public int getRetries() {
         return retries;
     }
@@ -307,7 +307,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #setImplicitWaitTime(int)}  instead
      */
-    @Deprecated(since="0.19.1")
+    @Deprecated//(since="0.19.1")
     public void setRetries(int retries) {
         this.retries = retries;
     }

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -26,8 +26,8 @@ public class ConductorConfig {
 
     // Conductor properties
     private String[] currentSchemes;
-    private int timeout = 5;
-    private int retries = 5;
+    private int appiumRequestTimeout = 5;
+    private int implicitWaitTime = 5;
     private boolean screenshotOnFail = true;
     private boolean screenshotOnSkip = false;
 
@@ -248,20 +248,20 @@ public class ConductorConfig {
         this.appiumVersion = appiumVersion;
     }
 
-    public int getTimeout() {
-        return timeout;
+    public int getAppiumRequestTimeout() {
+        return appiumRequestTimeout;
     }
 
-    public void setTimeout(int timeout) {
-        this.timeout = timeout;
+    public void setAppiumRequestTimeout(int appiumRequestTimeout) {
+        this.appiumRequestTimeout = appiumRequestTimeout;
     }
 
-    public int getRetries() {
-        return retries;
+    public int getImplicitWaitTime() {
+        return implicitWaitTime;
     }
 
-    public void setRetries(int retries) {
-        this.retries = retries;
+    public void setImplicitWaitTime(int implicitWaitTime) {
+        this.implicitWaitTime = implicitWaitTime;
     }
 
     public boolean isFullReset() {

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -29,13 +29,13 @@ public class ConductorConfig {
     /***
      * @deprecated in favor of {@link #appiumRequestTimeout} for clarity sake on what the variable actually is used for
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     private int timeout = 5; // deprecated in favor of `appiumRequestTimeout`
     private int appiumRequestTimeout = 5;
     /***
      * @deprecated in favor of {@link #implicitWaitTime} for clarity sake on what the variable actually is used for
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     private int retries = 5; // deprecated in favor of `implicitWaitTime`
     private int implicitWaitTime = 5;
     private boolean screenshotOnFail = true;
@@ -263,7 +263,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #getAppiumRequestTimeout()} instead
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     public int getTimeout() {
         return timeout;
     }
@@ -278,7 +278,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #setAppiumRequestTimeout(int)} instead
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }
@@ -292,7 +292,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #getImplicitWaitTime()} instead
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     public int getRetries() {
         return retries;
     }
@@ -307,7 +307,7 @@ public class ConductorConfig {
      *
      * @deprecated use {@link #setImplicitWaitTime(int)}  instead
      */
-    @Deprecated(since = "0.19.1")
+    @Deprecated(since="0.19.1")
     public void setRetries(int retries) {
         this.retries = retries;
     }

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -27,13 +27,13 @@ public class ConductorConfig {
     // Conductor properties
     private String[] currentSchemes;
     /***
-     * @deprecated in favor of {@link #appiumRequestTimeout} for clarity sake on what the variable actually is used for
+     * @deprecated in favor of {@link #appiumRequestTimeout} since 0.19.1 for clarity sake on what the variable actually is used for
      */
-    @Deprecated//(since="0.19.1")
+    @Deprecated
     private int timeout = 5; // deprecated in favor of `appiumRequestTimeout`
     private int appiumRequestTimeout = 5;
     /***
-     * @deprecated in favor of {@link #implicitWaitTime} for clarity sake on what the variable actually is used for
+     * @deprecated in favor of {@link #implicitWaitTime} since 0.19.1 for clarity sake on what the variable actually is used for
      */
     @Deprecated//(since="0.19.1")
     private int retries = 5; // deprecated in favor of `implicitWaitTime`
@@ -259,11 +259,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Returns the {@link #timeout} variable, which has been deprecated in favor of {@link #appiumRequestTimeout} for clarity
+     * Returns the {@link #timeout} variable, which has been deprecated since 0.19.1 in favor of {@link #appiumRequestTimeout} for clarity
      *
      * @deprecated use {@link #getAppiumRequestTimeout()} instead
      */
-    @Deprecated//(since="0.19.1")
+    @Deprecated
     public int getTimeout() {
         return timeout;
     }
@@ -273,12 +273,12 @@ public class ConductorConfig {
     }
 
     /***
-     * Sets the {@link #timeout} variable, which has been deprecated in favor of {@link #appiumRequestTimeout} for clarity
+     * Sets the {@link #timeout} variable, which has been deprecated since 0.19.1 in favor of {@link #appiumRequestTimeout} for clarity
      * Consider replacing the `timeout:` options in the config yaml with `appiumRequestTimeout`
      *
      * @deprecated use {@link #setAppiumRequestTimeout(int)} instead
      */
-    @Deprecated//(since="0.19.1")
+    @Deprecated
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }
@@ -288,11 +288,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Returns the {@link #retries} variable, which has been deprecated in favor of {@link #implicitWaitTime} for clarity
+     * Returns the {@link #retries} variable, which has been deprecated since 0.19.1 in favor of {@link #implicitWaitTime} for clarity
      *
      * @deprecated use {@link #getImplicitWaitTime()} instead
      */
-    @Deprecated//(since="0.19.1")
+    @Deprecated
     public int getRetries() {
         return retries;
     }
@@ -302,12 +302,12 @@ public class ConductorConfig {
     }
 
     /***
-     * Sets the {@link #retries} variable, which has been deprecated in favor of {@link #implicitWaitTime} for clarity
+     * Sets the {@link #retries} variable, which has been deprecated since 0.19.1 in favor of {@link #implicitWaitTime} for clarity
      * Consider replacing the `retries:` options in the config yaml with `implicitWaitTime`
      *
      * @deprecated use {@link #setImplicitWaitTime(int)}  instead
      */
-    @Deprecated//(since="0.19.1")
+    @Deprecated
     public void setRetries(int retries) {
         this.retries = retries;
     }

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -26,17 +26,7 @@ public class ConductorConfig {
 
     // Conductor properties
     private String[] currentSchemes;
-    /***
-     * @deprecated in favor of {@link #appiumRequestTimeout} since 0.19.1 for clarity sake on what the variable actually is used for
-     */
-    @Deprecated
-    private int timeout = 5; // deprecated in favor of `appiumRequestTimeout`
     private int appiumRequestTimeout = 5;
-    /***
-     * @deprecated in favor of {@link #implicitWaitTime} since 0.19.1 for clarity sake on what the variable actually is used for
-     */
-    @Deprecated//(since="0.19.1")
-    private int retries = 5; // deprecated in favor of `implicitWaitTime`
     private int implicitWaitTime = 5;
     private boolean screenshotOnFail = true;
     private boolean screenshotOnSkip = false;
@@ -185,6 +175,10 @@ public class ConductorConfig {
 
             if (key.equals(CUSTOM_CAPABILITIES)) {
                 putCustomCapabilities(properties.get(key));
+            } else if (key.equals("timeout") || key.equals("retries")){ //to automatically read deprecated
+                String newKey = key.equals("timeout") ? "appiumRequestTimeout" : "implicitWaitTime";
+                System.out.println("\"" + key + "\" has been deprecated. Please remove it from your config.yaml and replace it with \"" + newKey + "\"");
+                setProperty(newKey, properties.get(key).toString());
             } else {
                 setProperty(key, properties.get(key).toString());
             }
@@ -259,13 +253,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Returns the {@link #timeout} variable, which has been deprecated since 0.19.1 in favor of {@link #appiumRequestTimeout} for clarity
-     *
-     * @deprecated use {@link #getAppiumRequestTimeout()} instead
+     * @deprecated since 0.19.1, use {@link #getAppiumRequestTimeout()} instead
      */
     @Deprecated
     public int getTimeout() {
-        return timeout;
+        return appiumRequestTimeout;
     }
 
     public int getAppiumRequestTimeout() {
@@ -273,14 +265,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Sets the {@link #timeout} variable, which has been deprecated since 0.19.1 in favor of {@link #appiumRequestTimeout} for clarity
-     * Consider replacing the `timeout:` options in the config yaml with `appiumRequestTimeout`
-     *
-     * @deprecated use {@link #setAppiumRequestTimeout(int)} instead
+     * @deprecated since 0.19.1, use {@link #setAppiumRequestTimeout(int)} instead
      */
     @Deprecated
     public void setTimeout(int timeout) {
-        this.timeout = timeout;
+        this.appiumRequestTimeout = timeout;
     }
 
     public void setAppiumRequestTimeout(int appiumRequestTimeout) {
@@ -288,13 +277,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Returns the {@link #retries} variable, which has been deprecated since 0.19.1 in favor of {@link #implicitWaitTime} for clarity
-     *
-     * @deprecated use {@link #getImplicitWaitTime()} instead
+     * @deprecated since 0.19.1, use {@link #getImplicitWaitTime()} instead
      */
     @Deprecated
     public int getRetries() {
-        return retries;
+        return implicitWaitTime;
     }
 
     public int getImplicitWaitTime() {
@@ -302,14 +289,11 @@ public class ConductorConfig {
     }
 
     /***
-     * Sets the {@link #retries} variable, which has been deprecated since 0.19.1 in favor of {@link #implicitWaitTime} for clarity
-     * Consider replacing the `retries:` options in the config yaml with `implicitWaitTime`
-     *
-     * @deprecated use {@link #setImplicitWaitTime(int)}  instead
+     * @deprecated since 0.19.1, use {@link #setImplicitWaitTime(int)}  instead
      */
     @Deprecated
     public void setRetries(int retries) {
-        this.retries = retries;
+        this.implicitWaitTime = retries;
     }
 
     public void setImplicitWaitTime(int implicitWaitTime) {

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -351,10 +351,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return swipe(direction, /*element=*/null, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
-    public Locomotive swipeCenter(SwipeElementDirection direction, short numberOfSwipes) {
-     return swipeCenter(direction, 0, numberOfSwipes);
-    }
-
     public Locomotive swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
         short i = 0;
         while (i < numberOfSwipes) {
@@ -428,11 +424,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis) {
         return swipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
     }
-
-    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, short numberOfSwipes) {
-        return swipeCenterSuperLong(direction, 0, numberOfSwipes);
-    }
-
+    
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
         short i = 0;
         while (i < numberOfSwipes) {
@@ -551,10 +543,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
-    public Locomotive longPressSwipeCenter(SwipeElementDirection direction, short numberOfSwipes) {
-        return longPressSwipeCenter(direction, 0, numberOfSwipes);
-    }
-
     public Locomotive longPressSwipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
         short i = 0;
         while (i < numberOfSwipes) {
@@ -596,10 +584,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
     }
 
-    public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction, short numberOfSwipes) {
-        return longPressSwipeCenterLong(direction, 0, numberOfSwipes);
-    }
-
     public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
         short i = 0;
         while (i < numberOfSwipes) {
@@ -615,10 +599,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis) {
         return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
-    }
-
-    public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, short numberOfSwipes) {
-        return longPressSwipeCenterSuperLong(direction, 0, numberOfSwipes);
     }
 
     public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -7,10 +7,9 @@ import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import com.saucelabs.testng.SauceOnDemandAuthenticationProvider;
 
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.CommandExecutionHelper;
-import io.appium.java_client.MobileCommand;
 import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.AuthenticatesByFinger;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.PerformsTouchID;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
@@ -19,7 +18,6 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.service.local.flags.GeneralServerFlag;
 
 import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +34,6 @@ import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.pmw.tinylog.LogEntry;
 import org.pmw.tinylog.Logger;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -44,7 +41,6 @@ import org.testng.annotations.Listeners;
 
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,10 +131,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         // Set session ID after driver has been initialized
         SessionId id = getAppiumDriver().getSessionId();
         sessionId.set(id.toString());
-
-        // TODO: Added to support biometrics on android until java-client PR #473 is pulled in
-        MobileCommand.commandRepository.put("fingerPrint",
-                MobileCommand.postC("/session/:sessionId/appium/device/finger_print"));
     }
 
     void startAppiumSession(int startCounter) {
@@ -155,7 +147,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         // start a new session
         try {
-            URL                 hub          = configuration.getHub();
+            URL hub = configuration.getHub();
             DesiredCapabilities capabilities = onCapabilitiesCreated(getCapabilities(configuration));
 
             AppiumServiceBuilder builder = new AppiumServiceBuilder()
@@ -252,46 +244,27 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return waitForElement(PageUtil.buildBy(configuration, id));
     }
 
+    public WebElement waitForElement(String id, long timeoutInSeconds) {
+        return waitForElement(PageUtil.buildBy(configuration, id), timeoutInSeconds);
+    }
+
     public WebElement waitForElement(By by) {
+        return waitForElement(by, configuration.getAppiumRequestTimeout());
+    }
 
-        try {
-            waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOfElementLocated(by)));
-        } catch (Exception e) {
-            Logger.warn(e, "WaitForElement: Eat exception thrown waiting for condition");
-        }
-
-        int size = getAppiumDriver().findElements(by).size();
-
-        if (size == 0) {
-            int attempts = 1;
-            while (attempts <= configuration.getRetries()) {
-                try {
-                    Thread.sleep(1000); // sleep for 1 second.
-                } catch (Exception x) {
-                    Assert.fail("Failed due to an exception during Thread.sleep!");
-                    Logger.error(x);
-                }
-
-                size = getAppiumDriver().findElements(by).size();
-                if (size > 0) {
-                    break;
-                }
-                attempts++;
-            }
-            if (size == 0) {
-                Assert.fail(String.format("Could not find %s after %d attempts",
-                        by.toString(),
-                        configuration.getRetries()));
-            }
-        }
-
-        if (size > 1) {
-            Logger.error("WARN: There are more than 1 " + by.toString() + " 's!");
-        }
-
+    public WebElement waitForElement(By by, long timeoutInSeconds) {
+        waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOfElementLocated(by)), timeoutInSeconds);
         return getAppiumDriver().findElement(by);
     }
 
+    public WebElement waitForElement(WebElement element) {
+        return waitForElement(element, configuration.getAppiumRequestTimeout());
+    }
+
+    public WebElement waitForElement(WebElement element, long timeoutInSeconds) {
+        waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOf(element)), timeoutInSeconds);
+        return element;
+    }
 
     public Locomotive click(String id) {
         return click(PageUtil.buildBy(configuration, id));
@@ -336,11 +309,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return isPresentWait(by, 5);
     }
 
-    public boolean isPresentWait(String id, int timeOutInSeconds) {
+    public boolean isPresentWait(String id, long timeOutInSeconds) {
         return isPresentWait(PageUtil.buildBy(configuration, id), timeOutInSeconds);
     }
 
-    public boolean isPresentWait(By by, int timeOutInSeconds) {
+    public boolean isPresentWait(By by, long timeOutInSeconds) {
         waitForCondition(presenceOfAllElementsLocatedBy(by), timeOutInSeconds, 500);
         return isPresent(by);
     }
@@ -369,8 +342,38 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return element.getAttribute(attribute);
     }
 
+    //region Generic swipes
     public Locomotive swipeCenter(SwipeElementDirection direction) {
-        return performSwipe(direction, /*element=*/null, /*by=*/null, SWIPE_DISTANCE);
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE, 0);
+    }
+
+    public Locomotive swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE, swipeDurationInMillis);
+    }
+
+    public Locomotive swipeCenter(SwipeElementDirection direction, short numberOfSwipes) {
+     return swipeCenter(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            swipeCenter(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, String id, float percentage) {
+        return swipe(direction, PageUtil.buildBy(configuration, id), percentage);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, By by, float percentage) {
+        return swipe(direction, getAppiumDriver().findElement(by), percentage);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage) {
+        return swipe(direction, element, percentage, 0);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id) {
@@ -378,19 +381,65 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, By by) {
-        return swipe(direction, by, SWIPE_DISTANCE);
+        return swipe(direction, getAppiumDriver().findElement(by));
     }
 
     public Locomotive swipe(SwipeElementDirection direction, WebElement element) {
-        return performSwipe(direction, element, /*by=*/null, SWIPE_DISTANCE);
+        return swipe(direction, element, SWIPE_DISTANCE, 0);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
+        return swipe(direction, PageUtil.buildBy(configuration, id), swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
+        return swipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return swipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
     public Locomotive swipeCenterLong(SwipeElementDirection direction) {
-        return performSwipe(direction, /*element=*/null, /*by=*/null, SWIPE_DISTANCE_LONG);
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE_LONG, 0);
+    }
+
+    public Locomotive swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive swipeCenterLong(SwipeElementDirection direction, short numberOfSwipes) {
+        return swipeCenterLong(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            swipeCenterLong(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
     }
 
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction) {
-        return performSwipe(direction, /*element=*/null, /*by=*/null, SWIPE_DISTANCE_SUPER_LONG);
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, 0);
+    }
+
+    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return swipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, short numberOfSwipes) {
+        return swipeCenterSuperLong(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            swipeCenterSuperLong(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
     }
 
     public Locomotive swipeCornerLong(ScreenCorner corner, SwipeElementDirection direction, int duration) {
@@ -402,25 +451,43 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, String id) {
-        return swipeLong(direction, PageUtil.buildBy(configuration, id));
+        return swipe(direction, PageUtil.buildBy(configuration, id));
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, By by) {
-        return swipe(direction, by, SWIPE_DISTANCE_LONG);
+        return swipe(direction, getAppiumDriver().findElement(by));
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, WebElement element) {
-        return performSwipe(direction, element, /*by=*/null, SWIPE_DISTANCE_LONG);
+        return swipe(direction, element, SWIPE_DISTANCE_LONG, 0);
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, By by, float percentage) {
-        return performSwipe(direction, /*element=*/null, by, percentage);
+    public Locomotive swipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
+        return swipe(direction, PageUtil.buildBy(configuration, id), swipeDurationInMillis);
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage) {
-        return performSwipe(direction, element, /*by=*/null, percentage);
+    public Locomotive swipeLong(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
+        return swipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
     }
 
+    public Locomotive swipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return swipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+        return performSwipe(direction, false, element, percentage, swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(Point start, Point end, int swipeDurationInMillis) {
+        return performSwipe(false, start, end, swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(Point start, Point end) {
+        return swipe(start, end, 0);
+    }
+    //endregion Generic swipes
+
+    //region Directional swipes
     public void swipeDown() {
         swipeCenterLong(SwipeElementDirection.UP);
     }
@@ -461,6 +528,150 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
     }
 
+    /***
+     * Used to trigger iOS' gestural navigation back
+     * As of 8/29/2019, Android does not have this feature, but it may in the future
+     * More information on Android here: https://developer.android.com/preview/features/gesturalnav
+     */
+    public Locomotive swipeSystemBack() {
+        Dimension screen = getAppiumDriver().manage().window().getSize();
+        Point start = new Point(screen.getWidth() - 2, getYCenter());
+        Point end = new Point(2, getYCenter());
+
+        return swipe(start, end);
+    }
+    //endregion Directional swipes
+
+    //region longPress swipes
+    public Locomotive longPressSwipeCenter(SwipeElementDirection direction) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE, 0);
+    }
+
+    public Locomotive longPressSwipeCenter(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeCenter(SwipeElementDirection direction, short numberOfSwipes) {
+        return longPressSwipeCenter(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive longPressSwipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            longPressSwipeCenter(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, String id) {
+        return longPressSwipe(direction, PageUtil.buildBy(configuration, id));
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, By by) {
+        return longPressSwipe(direction, getAppiumDriver().findElement(by));
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element) {
+        return longPressSwipe(direction, element, SWIPE_DISTANCE, 0);
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
+        return longPressSwipe(direction, PageUtil.buildBy(configuration, id), swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
+        return longPressSwipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return longPressSwipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_LONG, 0);
+    }
+
+    public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction, short numberOfSwipes) {
+        return longPressSwipeCenterLong(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            longPressSwipeCenterLong(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
+    }
+
+    public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, 0);
+    }
+
+    public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis) {
+        return longPressSwipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, short numberOfSwipes) {
+        return longPressSwipeCenterSuperLong(direction, 0, numberOfSwipes);
+    }
+
+    public Locomotive longPressSwipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
+        short i = 0;
+        while (i < numberOfSwipes) {
+            longPressSwipeCenterSuperLong(direction, swipeDurationInMillis);
+            i++;
+        }
+        return this;
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, String id) {
+        return longPressSwipe(direction, PageUtil.buildBy(configuration, id));
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, By by) {
+        return longPressSwipe(direction, getAppiumDriver().findElement(by));
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element) {
+        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, 0);
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
+        return longPressSwipe(direction, PageUtil.buildBy(configuration, id), swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
+        return longPressSwipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+        return performSwipe(direction, true, element, percentage, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(Point start, Point end, int swipeDurationInMillis) {
+        return performSwipe(true, start, end, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(Point start, Point end) {
+        return longPressSwipe(start, end, 0);
+    }
+    //endregion longPress swipes
+
+    /*
+
+     */
+
+
     public Locomotive hideKeyboard() {
         try {
             getAppiumDriver().hideKeyboard();
@@ -470,18 +681,22 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return this;
     }
 
-    private Locomotive performSwipe(SwipeElementDirection direction, WebElement element, By by, float percentage) {
-        Point from;
-        if (element != null) {
-            from = getCenter(element);
-        } else if (by != null) {
-            from = getCenter(waitForElement(by));
-        } else {
-            from = getCenter(/*element=*/null);
-        }
+    /***
+     * Generic Perform Swipe Method
+     * Allows for different TouchAction presses: press() and longPress()
+     * Can accept different start and end Points, by Selenium's WebElement, By, or Points
+     *
+     * @param direction - nullable, but required if `to` is null
+     * @param isLongPress - determines TouchAction as `press()` or `longPress()`
+     * @param from - origin point of swipe, not nullable
+     * @param to - destination point of swipe, nullable, but required if `direction` is null
+     * @param percentage - modifies destination X and Y depending on `direction`
+     * @param swipeDurationInMillis - modifies duration of swipe
+     ***/
 
+    private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, Point from, Point to, float percentage, int swipeDurationInMillis) {
         Dimension screen = getAppiumDriver().manage().window().getSize();
-        Point to = null;
+
         if (direction != null) {
             switch (direction) {
                 case UP:
@@ -507,8 +722,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                 default:
                     throw new IllegalArgumentException("Swipe Direction not specified: " + direction.name());
             }
-        } else {
-            throw new IllegalArgumentException("Swipe Direction not specified");
+        } else if (to == null) {
+            throw new IllegalArgumentException("Swipe Direction and To Point are not specified.");
         }
 
         // Appium specifies that TouchAction.moveTo should be relative. iOS implements this correctly, but android
@@ -517,13 +732,35 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             to = new Point(to.getX() - from.getX(), to.getY() - from.getY());
         }
 
-        TouchAction swipe = new TouchAction(getAppiumDriver())
-                .press(point(from.getX(), from.getY()))
-                .waitAction(waitOptions(ofMillis(SWIPE_DURATION_MILLIS)))
-                .moveTo(point(to.getX(), to.getY()))
-                .release();
+        int swipeDuration = (swipeDurationInMillis != 0) ? swipeDurationInMillis : SWIPE_DURATION_MILLIS;
+
+        TouchAction swipe;
+        if (!isLongPress) {
+            swipe = new TouchAction(getAppiumDriver())
+                    .press(point(from.getX(), from.getY()))
+                    .waitAction(waitOptions(ofMillis(swipeDuration)))
+                    .moveTo(point(to.getX(), to.getY()))
+                    .release();
+        } else {
+            swipe = new TouchAction(getAppiumDriver())
+                    .longPress(point(from.getX(), from.getY()))
+                    .waitAction(waitOptions(ofMillis(swipeDuration)))
+                    .moveTo(point(to.getX(), to.getY()))
+                    .release();
+        }
+
         swipe.perform();
         return this;
+    }
+
+    //Overload method for using custom Points
+    private Locomotive performSwipe(boolean isLongPress, Point from, Point to, int swipeDurationInMillis) {
+        return performSwipe(null, isLongPress, from, to, 0, swipeDurationInMillis);
+    }
+
+    //Overload method for using WebElement, By, or String
+    private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, WebElement element, float percentage, int swipeDurationInMillis) {
+        return performSwipe(direction, isLongPress, getCenter(element), null, percentage, swipeDurationInMillis);
     }
 
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
@@ -645,15 +882,31 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      */
 
     public Point getCenter(WebElement element) {
-        int x, y;
+        return new Point(getXCenter(element), getYCenter(element));
+    }
+
+    public int getXCenter(WebElement element) {
         if (element == null) {
-            x = getAppiumDriver().manage().window().getSize().getWidth() / 2;
-            y = getAppiumDriver().manage().window().getSize().getHeight() / 2;
+            return getAppiumDriver().manage().window().getSize().getWidth() / 2;
         } else {
-            x = element.getLocation().getX() + (element.getSize().getWidth() / 2);
-            y = element.getLocation().getY() + (element.getSize().getHeight() / 2);
+            return element.getLocation().getX() + (element.getSize().getWidth() / 2);
         }
-        return new Point(x, y);
+    }
+
+    public int getXCenter() {
+        return getXCenter(null);
+    }
+
+    public int getYCenter(WebElement element) {
+        if (element == null) {
+            return getAppiumDriver().manage().window().getSize().getHeight() / 2;
+        } else {
+            return element.getLocation().getY() + (element.getSize().getHeight() / 2);
+        }
+    }
+
+    public int getYCenter() {
+        return getYCenter(null);
     }
 
     public List<WebElement> getElements(String id) {
@@ -851,10 +1104,9 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
         switch (configuration.getPlatformName()) {
             case ANDROID:
-                // TODO: Restructure when the Java-client supports biometrics (PR #473 on appium/java-client)
-                Map.Entry<String, Map<String, ?>> paramMap = new AbstractMap.SimpleEntry<>("fingerPrint",
-                        MobileCommand.prepareArguments("fingerprintId", id));
-                CommandExecutionHelper.execute(getAppiumDriver(), paramMap);
+                //Note: Biometrics are only supported on Android APIs 23 and above (6.0)
+                AuthenticatesByFinger authenticatesByFinger = (AuthenticatesByFinger) getAppiumDriver();
+                authenticatesByFinger.fingerPrint(id);
                 break;
 
             case IOS:
@@ -876,7 +1128,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      * @return The implementing class for fluency
      */
     public Locomotive waitForCondition(ExpectedCondition<?> condition) {
-        return waitForCondition(condition, configuration.getTimeout());
+        return waitForCondition(condition, configuration.getAppiumRequestTimeout());
     }
 
     /**

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -351,13 +351,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return swipe(direction, /*element=*/null, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
-    public Locomotive swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
-        short i = 0;
-        while (i < numberOfSwipes) {
-            swipeCenter(direction, swipeDurationInMillis);
-            i++;
-        }
-        return this;
+    public Locomotive swipeCenter(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes){
+        return repetitiveCenterSwipe(direction, swipeDurationInMillis, numberOfSwipes, SWIPE_DISTANCE);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id, float percentage) {
@@ -408,13 +403,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return swipeCenterLong(direction, 0, numberOfSwipes);
     }
 
-    public Locomotive swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
-        short i = 0;
-        while (i < numberOfSwipes) {
-            swipeCenterLong(direction, swipeDurationInMillis);
-            i++;
-        }
-        return this;
+    public Locomotive swipeCenterLong(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes){
+        return repetitiveCenterSwipe(direction, swipeDurationInMillis, numberOfSwipes, SWIPE_DISTANCE_LONG);
     }
 
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction) {
@@ -425,13 +415,8 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return swipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
     }
 
-    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
-        short i = 0;
-        while (i < numberOfSwipes) {
-            swipeCenterSuperLong(direction, swipeDurationInMillis);
-            i++;
-        }
-        return this;
+    public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes){
+        return repetitiveCenterSwipe(direction, swipeDurationInMillis, numberOfSwipes, SWIPE_DISTANCE_SUPER_LONG);
     }
 
     public Locomotive swipeCornerLong(ScreenCorner corner, SwipeElementDirection direction, int duration) {
@@ -477,6 +462,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public Locomotive swipe(Point start, Point end) {
         return swipe(start, end, 0);
     }
+
+    public Locomotive repetitiveCenterSwipe(SwipeElementDirection direction, int swipeDurationInMillis, int numberOfSwipes, float swipeDistance) {
+        int i = 0;
+        while (i < numberOfSwipes) {
+            swipe(direction, /*element=*/null, swipeDistance, swipeDurationInMillis);
+            i++;
+        }
+        return this;
+    }
+
     //endregion Generic swipes
 
     //region Directional swipes

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -424,7 +424,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis) {
         return swipe(direction, /*element=*/null, SWIPE_DISTANCE_SUPER_LONG, swipeDurationInMillis);
     }
-    
+
     public Locomotive swipeCenterSuperLong(SwipeElementDirection direction, int swipeDurationInMillis, short numberOfSwipes){
         short i = 0;
         while (i < numberOfSwipes) {

--- a/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/ConductorConfigTest.java
@@ -65,9 +65,9 @@ public class ConductorConfigTest {
                 .isFalse();
         Assertions.assertThat(config.getAppiumVersion())
                 .isEqualTo("1.13.0");
-        Assertions.assertThat(config.getTimeout())
+        Assertions.assertThat(config.getAppiumRequestTimeout())
                 .isEqualTo(8);
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(10);
     }
 
@@ -78,7 +78,7 @@ public class ConductorConfigTest {
         Assertions.assertThat(config.getPlatformName())
                 .isEqualByComparingTo(Platform.ANDROID);
         // Tests that platform overrides defaults
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(4);
         Assertions.assertThat(config.getAppFile())
                 .isEqualTo("./apps/android.apk");
@@ -95,7 +95,7 @@ public class ConductorConfigTest {
 
         Assertions.assertThat(config.getPlatformName())
                 .isEqualByComparingTo(Platform.IOS);
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(2);
         Assertions.assertThat(config.getAppFile())
                 .isEqualTo("./apps/ios.app");
@@ -116,9 +116,9 @@ public class ConductorConfigTest {
                 .isEqualByComparingTo(Platform.IOS);
         Assertions.assertThat(config.getCurrentSchemes())
                 .isEqualTo(new String[] { "longer_timeouts", "ios_device" });
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(3);
-        Assertions.assertThat(config.getTimeout())
+        Assertions.assertThat(config.getAppiumRequestTimeout())
                 .isEqualTo(20);
         Assertions.assertThat(config.getAppFile())
                 .isEqualTo("./apps/ios.ipa");
@@ -132,9 +132,9 @@ public class ConductorConfigTest {
                 .isEqualByComparingTo(Platform.IOS);
         Assertions.assertThat(config.getCurrentSchemes())
                 .isEqualTo(new String[] { "longer_timeouts", "ios_saucelabs" });
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(1);
-        Assertions.assertThat(config.getTimeout())
+        Assertions.assertThat(config.getAppiumRequestTimeout())
                 .isEqualTo(20);
         Assertions.assertThat(config.getAppFile())
                 .isEqualTo("sauce-storage:mock.zip");
@@ -158,9 +158,9 @@ public class ConductorConfigTest {
 
         Assertions.assertThat(config.getPlatformName())
                 .isEqualByComparingTo(Platform.ANDROID);
-        Assertions.assertThat(config.getRetries())
+        Assertions.assertThat(config.getImplicitWaitTime())
                 .isEqualTo(8);
-        Assertions.assertThat(config.getTimeout())
+        Assertions.assertThat(config.getAppiumRequestTimeout())
                 .isEqualTo(5);
         Assertions.assertThat(config.getUdid())
                 .isEqualTo("auto");

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static com.joss.conductor.mobile.MockTestUtil.matchesEntriesIn;
 import static com.joss.conductor.mobile.SwipeElementDirection.DOWN;
@@ -135,65 +136,6 @@ public class LocomotiveTest {
                 .isEqualTo("com.android.activity");
         Assertions.assertThat(caps.getCapability(MobileCapabilityType.NO_RESET))
                 .isEqualTo(false);
-    }
-
-    @Test
-    public void test_wait_for_elem_found_on_first_try() {
-        By id = mock(By.class);
-        WebElement foundElement = mock(WebElement.class);
-        androidConfig.setAppiumRequestTimeout(0);
-
-        when(mockDriver.findElements(id)).thenReturn(Collections.singletonList(foundElement));
-        when(mockDriver.findElement(id)).thenReturn(foundElement);
-        Locomotive locomotive = new Locomotive();
-        locomotive.setConfiguration(androidConfig);
-        locomotive.setAppiumDriver(mockDriver);
-
-        Assertions.assertThat(locomotive.waitForElement(id))
-                .isEqualTo(foundElement);
-        verify(mockDriver, times(1))
-                .findElements(id);
-    }
-
-    @Test
-    public void test_wait_for_ele_retries_and_fail() {
-        int numberOfRetries = 5;
-        iosConfig.setImplicitWaitTime(numberOfRetries);
-        iosConfig.setAppiumRequestTimeout(0);
-
-        final By id = mock(By.class);
-        when(mockDriver.findElements(id)).thenReturn(Collections.emptyList());
-        final Locomotive locomotive = new Locomotive()
-                .setConfiguration(iosConfig)
-                .setAppiumDriver(mockDriver);
-
-        Assertions.assertThatThrownBy(() -> locomotive.waitForElement(id)).isInstanceOf(AssertionError.class);
-        // First attempt to find elements plus 5 retries + one added from the driver
-        verify(mockDriver, times(numberOfRetries + 1))
-                .findElements(id);
-    }
-
-    @Test
-    public void test_wait_for_ele_retries_and_find_item() {
-        int numberOfRetries = 5;
-        iosConfig.setImplicitWaitTime(numberOfRetries);
-        iosConfig.setAppiumRequestTimeout(0);
-
-        WebElement foundElement = mock(WebElement.class);
-        By id = mock(By.class);
-
-        when(mockDriver.findElements(id)).thenReturn(Collections.emptyList(),
-                Collections.emptyList(),
-                Collections.singletonList(foundElement));
-        when(mockDriver.findElement(id)).thenReturn(foundElement);
-        Locomotive locomotive = new Locomotive()
-                .setConfiguration(iosConfig)
-                .setAppiumDriver(mockDriver);
-
-        Assertions.assertThat(locomotive.waitForElement(id))
-                .isEqualTo(foundElement);
-        verify(mockDriver, times(3)) // Found on it's 3rd attempt
-                .findElements(id);
     }
 
     @Test

--- a/src/test/resources/test_yaml/all_platforms.yaml
+++ b/src/test/resources/test_yaml/all_platforms.yaml
@@ -6,27 +6,27 @@ currentSchemes:
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID
 
 shorter_timeouts:
-  retries: 8
-  timeout: 5
+  implicitWaitTime: 8
+  appiumRequestTimeout: 5
 
 longer_timeouts:
-  retries: 5
-  timeout: 20
+  implicitWaitTime: 5
+  appiumRequestTimeout: 20
 
 android_device:
   udid: auto

--- a/src/test/resources/test_yaml/android_defaults.yaml
+++ b/src/test/resources/test_yaml/android_defaults.yaml
@@ -4,16 +4,16 @@ platformName: ANDROID
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID

--- a/src/test/resources/test_yaml/android_defaults_custom_caps.yaml
+++ b/src/test/resources/test_yaml/android_defaults_custom_caps.yaml
@@ -4,8 +4,8 @@ platformName: ANDROID
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
   customCapabilities:
     foo: bar
     fizz: buzz
@@ -13,12 +13,12 @@ defaults:
 
   android:
     deviceName: device
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID

--- a/src/test/resources/test_yaml/android_defaults_custom_caps_schemes.yaml
+++ b/src/test/resources/test_yaml/android_defaults_custom_caps_schemes.yaml
@@ -6,19 +6,19 @@ platformName: ANDROID
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
   customCapabilities:
     foo: bar
     fizz: buzz
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID

--- a/src/test/resources/test_yaml/environment_vars.yaml
+++ b/src/test/resources/test_yaml/environment_vars.yaml
@@ -4,7 +4,7 @@ platformName: IOS
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
   udid: ${FOO_PROPERTY}
   platformVersion: ${PLATFORM_MAJOR}.${PLATFORM_MINOR}

--- a/src/test/resources/test_yaml/ios_defaults.yaml
+++ b/src/test/resources/test_yaml/ios_defaults.yaml
@@ -4,16 +4,16 @@ platformName: IOS
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 2
+    implicitWaitTime: 2
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID

--- a/src/test/resources/test_yaml/override_schemes.yaml
+++ b/src/test/resources/test_yaml/override_schemes.yaml
@@ -8,29 +8,29 @@ currentSchemes:
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID
 
 longer_timeouts:
-  retries: 3
-  timeout: 20
+  implicitWaitTime: 3
+  appiumRequestTimeout: 20
 
 ios_device:
   appFile: ./apps/ios.ipa
   udid: auto
 
 ios_saucelabs:
-  retries: 1
+  implicitWaitTime: 1
   appFile: sauce-storage:mock.zip
   platformVersion: 11.0

--- a/src/test/resources/test_yaml/schemes.yaml
+++ b/src/test/resources/test_yaml/schemes.yaml
@@ -8,23 +8,23 @@ currentSchemes:
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10
 
   android:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/android.apk
     appActivity: com.android.activity
 
   ios:
-    retries: 4
+    implicitWaitTime: 4
     appFile: ./apps/ios.app
     xcodeSigningId: iPhone Developer
     xcodeOrgId: TEAMID
 
 longer_timeouts:
-  retries: 3
-  timeout: 20
+  implicitWaitTime: 3
+  appiumRequestTimeout: 20
 
 ios_device:
   appFile: ./apps/ios.ipa

--- a/src/test/resources/test_yaml/simple_defaults.yaml
+++ b/src/test/resources/test_yaml/simple_defaults.yaml
@@ -4,5 +4,5 @@ platformName: IOS
 defaults:
   noReset: false
   appiumVersion: 1.13.0
-  timeout: 8
-  retries: 10
+  appiumRequestTimeout: 8
+  implicitWaitTime: 10


### PR DESCRIPTION
### Related Issue
closes #126 
closes #125 
closes #49 
closes #10 

### Description
Whew.
_*Swipes*_
- Refactored main `performSwipe` method to now take in Point instead of element/by.
- Added corresponding overloads to convert element/by/string into Point
- Added duration as an option (#49)
- Added longPress as an option (#125)
- Added corresponding swipe and longPressSwipe methods for the new performSwipe options

_*waitForElement*_ (#126)
- Simplified the `waitForElement` method
- Added methods for custom timeout lengths

_*config variables*_ (#10)
- Renamed variables
- Renamed getters and setters

### Additional Info
**Breaking Change Information**
- In order to fix #10, I renamed the ConductorConfig variables `timeout` and `retries` to `appiumRequestTimeout` and `implicitWaitTime` respectively. This also involved updating our config yaml files, and if you are using a custom config.yaml file for your implementation of Conductor-mobile, you will need to update the variables there as well.

Shoutout to @mrk-han for answering all of my questions about how things are meant to be

### Checklist

* [x] Have you added an explanation of what your changes do?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Docs have been added / updated (for bug fixes / features)
