### PR TITLE
Fix isPresentWait and Remove support for JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,0 @@
-jdk:
-  - oraclejdk8
-install:
-  - ./gradlew assemble publishToMavenLocal

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -46,6 +46,7 @@ import static io.appium.java_client.touch.WaitOptions.waitOptions;
 import static io.appium.java_client.touch.offset.PointOption.point;
 import static java.time.Duration.ofMillis;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfAllElementsLocatedBy;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
 
 /**
  * Created on 8/10/16.
@@ -310,7 +311,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     public boolean isPresentWait(By by, long timeOutInSeconds) {
         try {
-            waitForCondition(presenceOfAllElementsLocatedBy(by), timeOutInSeconds, 500);
+            waitForCondition(visibilityOfAllElementsLocatedBy(by), timeOutInSeconds, 500);
             return true;
         } catch (TimeoutException e) {
             return false;

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -23,12 +23,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.Point;
-import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.WebElement;
+import org.junit.rules.Timeout;
+import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -314,8 +310,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public boolean isPresentWait(By by, long timeOutInSeconds) {
-        waitForCondition(presenceOfAllElementsLocatedBy(by), timeOutInSeconds, 500);
-        return isPresent(by);
+        try {
+            waitForCondition(presenceOfAllElementsLocatedBy(by), timeOutInSeconds, 500);
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
     }
 
     public String getText(String id) {

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -151,7 +151,7 @@ public class LocomotiveTest {
 
         Assertions.assertThat(locomotive.isPresentWait(id))
                 .isEqualTo(true);
-        verify(mockDriver, times(2))
+        verify(mockDriver, times(1))
                 .findElements(id);
     }
 


### PR DESCRIPTION
Fix isPresentWait
- add exception handling for when element is not found
- change to search for visibility instead of presence
Delete jitpack.yaml
-  remove support for jitpack

### Related Issue

closes #128 - we are retiring support for jitpack in favor of maven central
closes #129

### Description
- Removed the `jitpack.yaml` file which should signal the end of the jitpack support. We will need to note these in the 0.19.1 release notes
- Fixed a few issues with the new version of `isPresentWait`
-- Added exception handling for when the element isn't found, so that we can return a `false` value
-- Swapped out `presenceOf`... for `visibilityOf`..., as there are a _few_ times where an element will exist but not be visible (main example is iOS modal presentations)

### Additional Info
Shoutout @evant for helping with the exception stuff
Shoutout @mrk-han for helping with the jitpack stuff

Also if anyone has extra information about retiring jitpack, just let me know
### Checklist

* [x] Have you added an explanation of what your changes do?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Docs have been added / updated (for bug fixes / features)
