### PR TITLE
Chore/migrate to mobile element

### DIFF
--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -7,6 +7,8 @@ import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import com.saucelabs.testng.SauceOnDemandAuthenticationProvider;
 
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.MobileDriver;
+import io.appium.java_client.MobileElement;
 import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.AuthenticatesByFinger;
@@ -45,8 +47,7 @@ import java.util.regex.Pattern;
 import static io.appium.java_client.touch.WaitOptions.waitOptions;
 import static io.appium.java_client.touch.offset.PointOption.point;
 import static java.time.Duration.ofMillis;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfAllElementsLocatedBy;
-import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
+import static org.openqa.selenium.support.ui.ExpectedConditions.*;
 
 /**
  * Created on 8/10/16.
@@ -236,28 +237,38 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     /**
      * Method that acts as an arbiter of implicit timeouts of sorts
      */
-    public WebElement waitForElement(String id) {
+    public MobileElement waitForElement(String id) {
         return waitForElement(PageUtil.buildBy(configuration, id));
     }
 
-    public WebElement waitForElement(String id, long timeoutInSeconds) {
+    public MobileElement waitForElement(String id, long timeoutInSeconds) {
         return waitForElement(PageUtil.buildBy(configuration, id), timeoutInSeconds);
     }
 
-    public WebElement waitForElement(By by) {
+    public MobileElement waitForElement(By by) {
         return waitForElement(by, configuration.getAppiumRequestTimeout());
     }
 
-    public WebElement waitForElement(By by, long timeoutInSeconds) {
+    public MobileElement waitForElement(By by, long timeoutInSeconds) {
         waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOfElementLocated(by)), timeoutInSeconds);
-        return getAppiumDriver().findElement(by);
+        return (MobileElement) getAppiumDriver().findElement(by);
     }
 
-    public WebElement waitForElement(WebElement element) {
+    @Deprecated
+    public MobileElement waitForElement(WebElement element) {
+        return waitForElement((MobileElement) element);
+    }
+
+    @Deprecated
+    public MobileElement waitForElement(WebElement element, long timeoutInSeconds) {
+        return waitForElement((MobileElement) element, timeoutInSeconds);
+    }
+
+    public MobileElement waitForElement(MobileElement element) {
         return waitForElement(element, configuration.getAppiumRequestTimeout());
     }
 
-    public WebElement waitForElement(WebElement element, long timeoutInSeconds) {
+    public MobileElement waitForElement(MobileElement element, long timeoutInSeconds) {
         waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOf(element)), timeoutInSeconds);
         return element;
     }
@@ -270,7 +281,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return click(waitForElement(by));
     }
 
-    public Locomotive click(WebElement element) {
+    public Locomotive click(MobileElement element) {
         try {
             element.click();
             return this;
@@ -281,6 +292,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
     }
 
+    @Deprecated
+    public Locomotive click(WebElement element) {
+        return click((MobileElement) element);
+    }
+
     public Locomotive setText(String id, String text) {
         return setText(PageUtil.buildBy(configuration, id), text);
     }
@@ -289,7 +305,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return setText(waitForElement(by), text);
     }
 
-    public Locomotive setText(WebElement element, String text) {
+    public Locomotive setText(MobileElement element, String text) {
         try {
             element.clear();
             element.sendKeys(text);
@@ -301,6 +317,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
     }
 
+    @Deprecated
+    public Locomotive setText(WebElement element, String text) {
+        return setText((MobileElement) element, text);
+    }
+
     public boolean isPresent(String id) {
         return isPresent(PageUtil.buildBy(configuration, id));
     }
@@ -309,12 +330,20 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return getAppiumDriver().findElements(by).size() > 0;
     }
 
+    public boolean isPresent(MobileElement mobileElement) {
+        return mobileElement.isDisplayed();
+    }
+
     public boolean isPresentWait(String id) {
         return isPresentWait(PageUtil.buildBy(configuration, id), 5);
     }
 
     public boolean isPresentWait(By by) {
         return isPresentWait(by, 5);
+    }
+
+    public boolean isPresentWait(MobileElement element) {
+        return isPresentWait(element, 5);
     }
 
     public boolean isPresentWait(String id, long timeOutInSeconds) {
@@ -330,6 +359,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         }
     }
 
+    public boolean isPresentWait(MobileElement element, long timeOutInSeconds) {
+        try {
+            waitForCondition(visibilityOf(element), timeOutInSeconds, 500);
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
     public String getText(String id) {
         return getText(PageUtil.buildBy(configuration, id));
     }
@@ -338,11 +376,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return getText(waitForElement(by));
     }
 
-    public String getText(WebElement element) {
+    @Deprecated
+    public String getText(WebElement webElement) {
+        return getText((MobileElement) webElement);
+    }
+
+    public String getText (MobileElement mobileElement) {
         try {
-            return element.getText();
-        }  catch (NoSuchElementException noSuchElementException) {
-            throw new NoSuchElementException("Error: Unable to find element: " + element.toString() + " in order to get the text of the element", noSuchElementException);
+            return mobileElement.getText();
+        } catch (NoSuchElementException noSuchElementException) {
+            throw new NoSuchElementException("Error: Unable to find element: " + mobileElement.toString() + " in order to get the text of the element", noSuchElementException);
         } catch (Exception exception) {
             throw exception;
         }
@@ -356,7 +399,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return waitForElement(by).getAttribute(attribute);
     }
 
-    public String getAttribute(WebElement element, String attribute) {
+    public String getAttribute(MobileElement element, String attribute) {
         try {
             return element.getAttribute(attribute);
         } catch (NoSuchElementException noSuchElementException) {
@@ -364,6 +407,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         } catch (Exception exception) {
             throw exception;
         }
+    }
+
+    @Deprecated
+    public String getAttribute(WebElement element, String attribute) {
+        return getAttribute((MobileElement) element, attribute);
     }
 
     //region Generic swipes
@@ -384,11 +432,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, By by, float percentage) {
-        return swipe(direction, getAppiumDriver().findElement(by), percentage);
+        return swipe(direction, (MobileElement) getAppiumDriver().findElement(by), percentage);
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage) {
+    public Locomotive swipe(SwipeElementDirection direction, MobileElement element, float percentage) {
         return swipe(direction, element, percentage, 0);
+    }
+
+    @Deprecated
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage) {
+        return swipe(direction, (MobileElement) element, percentage);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id) {
@@ -396,11 +449,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, By by) {
-        return swipe(direction, getAppiumDriver().findElement(by));
+        return swipe(direction, (MobileElement) getAppiumDriver().findElement(by));
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, WebElement element) {
+    public Locomotive swipe(SwipeElementDirection direction, MobileElement element) {
         return swipe(direction, element, SWIPE_DISTANCE, 0);
+    }
+
+    @Deprecated
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element) {
+        return swipe(direction, (MobileElement) element);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -408,11 +466,17 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
-        return swipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+        return swipe(direction, (MobileElement) getAppiumDriver().findElement(by), swipeDurationInMillis);
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+
+    public Locomotive swipe(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
         return swipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
+    }
+
+    @Deprecated
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return swipe(direction, (MobileElement) element, swipeDurationInMillis);
     }
 
     public Locomotive swipeCenterLong(SwipeElementDirection direction) {
@@ -456,11 +520,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, By by) {
-        return swipe(direction, getAppiumDriver().findElement(by));
+        return swipe(direction, (MobileElement) getAppiumDriver().findElement(by));
     }
 
-    public Locomotive swipeLong(SwipeElementDirection direction, WebElement element) {
+    public Locomotive swipeLong(SwipeElementDirection direction, MobileElement element) {
         return swipe(direction, element, SWIPE_DISTANCE_LONG, 0);
+    }
+
+    @Deprecated
+    public Locomotive swipeLong(SwipeElementDirection direction, WebElement element) {
+        return swipeLong(direction, (MobileElement) element);
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -468,15 +537,26 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
-        return swipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+        return swipe(direction, (MobileElement) getAppiumDriver().findElement(by), swipeDurationInMillis);
     }
 
-    public Locomotive swipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+    public Locomotive swipeLong(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
         return swipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+
     }
 
-    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+    @Deprecated
+    public Locomotive swipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return swipeLong(direction, (MobileElement) element, swipeDurationInMillis);
+    }
+
+    public Locomotive swipe(SwipeElementDirection direction, MobileElement element, float percentage, int swipeDurationInMillis) {
         return performSwipe(direction, false, element, percentage, swipeDurationInMillis);
+    }
+
+    @Deprecated
+    public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+        return swipe(direction, (MobileElement) element, percentage, swipeDurationInMillis);
     }
 
     public Locomotive swipe(Point start, Point end, int swipeDurationInMillis) {
@@ -576,11 +656,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, By by) {
-        return longPressSwipe(direction, getAppiumDriver().findElement(by));
+        return longPressSwipe(direction, (MobileElement) getAppiumDriver().findElement(by));
     }
 
-    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element) {
+    public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element) {
         return longPressSwipe(direction, element, SWIPE_DISTANCE, 0);
+    }
+
+    @Deprecated
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element) {
+        return longPressSwipe(direction, (MobileElement) element);
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -588,11 +673,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
-        return longPressSwipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+        return longPressSwipe(direction, (MobileElement) getAppiumDriver().findElement(by), swipeDurationInMillis);
     }
 
-    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+    public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
         return longPressSwipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
+    }
+
+    @Deprecated
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return longPressSwipe(direction, (MobileElement) element, swipeDurationInMillis);
     }
 
     public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction) {
@@ -634,11 +724,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, By by) {
-        return longPressSwipe(direction, getAppiumDriver().findElement(by));
+        return longPressSwipe(direction, (MobileElement) getAppiumDriver().findElement(by));
     }
 
-    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element) {
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, MobileElement element) {
         return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, 0);
+    }
+
+    @Deprecated
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element) {
+        return longPressSwipeLong(direction, (MobileElement) element);
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -646,15 +741,25 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, By by, int swipeDurationInMillis) {
-        return longPressSwipe(direction, getAppiumDriver().findElement(by), swipeDurationInMillis);
+        return longPressSwipe(direction, (MobileElement) getAppiumDriver().findElement(by), swipeDurationInMillis);
     }
 
-    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
         return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
     }
 
-    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+    @Deprecated
+    public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
+        return longPressSwipeLong(direction, (MobileElement) element, swipeDurationInMillis);
+    }
+
+    public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element, float percentage, int swipeDurationInMillis) {
         return performSwipe(direction, true, element, percentage, swipeDurationInMillis);
+    }
+
+    @Deprecated
+    public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
+        return longPressSwipe(direction, (MobileElement) element, percentage, swipeDurationInMillis);
     }
 
     public Locomotive longPressSwipe(Point start, Point end, int swipeDurationInMillis) {
@@ -665,11 +770,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return longPressSwipe(start, end, 0);
     }
     //endregion longPress swipes
-
-    /*
-
-     */
-
 
     public Locomotive hideKeyboard() {
         try {
@@ -683,7 +783,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     /***
      * Generic Perform Swipe Method
      * Allows for different TouchAction presses: press() and longPress()
-     * Can accept different start and end Points, by Selenium's WebElement, By, or Points
+     * Can accept different start and end Points, by Appium's MobileElement, By, or Points
      *
      * @param direction - nullable, but required if `to` is null
      * @param isLongPress - determines TouchAction as `press()` or `longPress()`
@@ -757,9 +857,14 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return performSwipe(null, isLongPress, from, to, 0, swipeDurationInMillis);
     }
 
-    //Overload method for using WebElement, By, or String
-    private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, WebElement element, float percentage, int swipeDurationInMillis) {
+    //Overload method for using MobileElement, By, or String
+    private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, MobileElement element, float percentage, int swipeDurationInMillis) {
         return performSwipe(direction, isLongPress, getCenter(element), null, percentage, swipeDurationInMillis);
+    }
+
+    @Deprecated
+    private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, WebElement element, float percentage, int swipeDurationInMillis) {
+        return performSwipe(direction, isLongPress, getCenter((MobileElement) element), null, percentage, swipeDurationInMillis);
     }
 
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
@@ -835,12 +940,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return this;
     }
 
-    public WebElement swipeTo(SwipeElementDirection direction, By by, int attempts) {
-        WebElement element;
+    public MobileElement swipeTo(SwipeElementDirection direction, By by, int attempts) {
+        MobileElement element;
         for (int i = 0; i < attempts; i++) {
             swipeCenterLong(direction);
             try {
-                element = getAppiumDriver().findElement(by);
+                element = (MobileElement) getAppiumDriver().findElement(by);
                 // element was found, check for visibility
                 if (element.isDisplayed()) {
                     // element is in view, exit the loop
@@ -856,20 +961,20 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return null;
     }
 
-    public WebElement swipeTo(By by) {
+    public MobileElement swipeTo(By by) {
         SwipeElementDirection s = SwipeElementDirection.UP;
         int attempts = 3;
 
         return swipeTo(s, by, attempts);
     }
 
-    public WebElement swipeTo(SwipeElementDirection direction, By by) {
+    public MobileElement swipeTo(SwipeElementDirection direction, By by) {
         int attempts = 3;
 
         return swipeTo(direction, by, attempts);
     }
 
-    public WebElement swipeTo(SwipeElementDirection direction, String id, int attempts) {
+    public MobileElement swipeTo(SwipeElementDirection direction, String id, int attempts) {
         return swipeTo(direction, By.id(id), attempts);
     }
 
@@ -880,11 +985,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      * @return Point centered on the provided element or screen.
      */
 
-    public Point getCenter(WebElement element) {
+    public Point getCenter(MobileElement element) {
         return new Point(getXCenter(element), getYCenter(element));
     }
 
-    public int getXCenter(WebElement element) {
+    @Deprecated
+    public Point getCenter(WebElement element) {
+        return getCenter((MobileElement) element);
+    }
+
+    public int getXCenter(MobileElement element) {
         if (element == null) {
             return getAppiumDriver().manage().window().getSize().getWidth() / 2;
         } else {
@@ -896,7 +1006,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return getXCenter(null);
     }
 
-    public int getYCenter(WebElement element) {
+    @Deprecated
+    public int getXCenter(WebElement element) {
+        return getXCenter((MobileElement) element);
+    }
+
+    public int getYCenter(MobileElement element) {
         if (element == null) {
             return getAppiumDriver().manage().window().getSize().getHeight() / 2;
         } else {
@@ -908,11 +1023,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return getYCenter(null);
     }
 
-    public List<WebElement> getElements(String id) {
+    @Deprecated
+    public int getYCenter(WebElement element) {
+        return getYCenter((MobileElement) element);
+    }
+
+    public List<MobileElement> getElements(String id) {
         return getElements(PageUtil.buildBy(configuration, id));
     }
 
-    public List<WebElement> getElements(By by) {
+    public List<MobileElement> getElements(By by) {
         waitForElement(by);
         return getAppiumDriver().findElements(by);
     }
@@ -951,22 +1071,32 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return validateTextIgnoreCase(waitForElement(by), text);
     }
 
-    public Locomotive validateTextIgnoreCase(WebElement element, String text) {
+    public Locomotive validateTextIgnoreCase(MobileElement element, String text) {
         String actual = getText(element);
         Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
                 text.equalsIgnoreCase(actual));
         return this;
     }
 
+    @Deprecated
+    public Locomotive validateTextIgnoreCase(WebElement element, String text) {
+        return validateTextIgnoreCase((MobileElement) element, text);
+    }
+
     public Locomotive validateText(By by, String text) {
         return validateText(waitForElement(by), text);
     }
 
-    public Locomotive validateText(WebElement element, String text) {
+    public Locomotive validateText(MobileElement element, String text) {
         String actual = getText(element);
         Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
                 text.equals(actual));
         return this;
+    }
+
+    @Deprecated
+    public Locomotive validateText(WebElement element, String text) {
+        return validateText((MobileElement) element, text);
     }
 
     public Locomotive validateTextNot(String id, String text) {
@@ -981,22 +1111,32 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return validateTextNotIgnoreCase(waitForElement(by), text);
     }
 
-    public Locomotive validateTextNotIgnoreCase(WebElement element, String text) {
+    public Locomotive validateTextNotIgnoreCase(MobileElement element, String text) {
         String actual = getText(element);
         Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
                 text.equalsIgnoreCase(actual));
         return this;
     }
 
+    @Deprecated
+    public Locomotive validateTextNotIgnoreCase(WebElement element, String text) {
+       return validateTextNotIgnoreCase((MobileElement) element, text);
+    }
+
     public Locomotive validateTextNot(By by, String text) {
         return validateTextNot(waitForElement(by), text);
     }
 
-    public Locomotive validateTextNot(WebElement element, String text) {
+    public Locomotive validateTextNot(MobileElement element, String text) {
         String actual = getText(element);
         Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
                 text.equals(actual));
         return this;
+    }
+
+    @Deprecated
+    public Locomotive validateTextNot(WebElement element, String text) {
+        return validateTextNot((MobileElement) element, text);
     }
 
     public Locomotive validateTextPresent(String text) {
@@ -1009,38 +1149,43 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return this;
     }
 
-    public Locomotive validateAttribute(String id, String attr, String regex) {
-        return validateAttribute(PageUtil.buildBy(configuration, id), attr, regex);
+    public Locomotive validateAttribute(String id, String attr, String expected) {
+        return validateAttribute(PageUtil.buildBy(configuration, id), attr, expected);
     }
 
-    public Locomotive validateAttribute(By by, String attr, String regex) {
-        return validateAttribute(waitForElement(by), attr, regex);
+    public Locomotive validateAttribute(By by, String attr, String expected) {
+        return validateAttribute(waitForElement(by), attr, expected);
     }
 
-    public Locomotive validateAttribute(WebElement element, String attr, String regex) {
+    public Locomotive validateAttribute(MobileElement element, String attr, String expected) {
         String actual = null;
         try {
             actual = element.getAttribute(attr);
-            if (actual.equals(regex)) return this; // test passes.
+            if (actual.equals(expected)) return this; // test passes.
         } catch (NoSuchElementException e) {
             Assert.fail("No such element [" + element.toString() + "] exists.");
         } catch (Exception x) {
             Assert.fail("Cannot validate an attribute if an element doesn't have it!");
         }
 
-        Pattern p = Pattern.compile(regex);
+        Pattern p = Pattern.compile(expected);
         Matcher m = p.matcher(actual);
 
         Assert.assertTrue(
                 String.format("Attribute doesn't match! [Selector: %s] [Attribute: %s] [Desired value: %s] [Actual value: %s]",
                         element.toString(),
                         attr,
-                        regex,
+                        expected,
                         actual
                 ),
                 m.find());
 
         return this;
+    }
+
+    @Deprecated
+    public Locomotive validateAttribute(WebElement element, String attr, String regex) {
+        return validateAttribute((MobileElement) element, attr, regex);
     }
 
     public Locomotive validateTrue(boolean condition) {
@@ -1147,9 +1292,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         return this;
     }
 
-
     public Locomotive waitUntilNotPresent(String id) {
-        return waitForCondition(ExpectedConditions.invisibilityOfElementLocated(PageUtil.buildBy(configuration, id)));
+        return waitUntilNotPresent(PageUtil.buildBy(configuration, id));
+    }
+
+    public Locomotive waitUntilNotPresent(By by) {
+        return waitForCondition(ExpectedConditions.invisibilityOfElementLocated(by));
+    }
+
+    public Locomotive waitUntilNotPresent(MobileElement element) {
+        return waitForCondition(ExpectedConditions.invisibilityOf(element));
     }
 
     public String getTestMethodName() {
@@ -1165,4 +1317,13 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     public SauceOnDemandAuthentication getAuthentication() {
         return configuration.getSauceAuthentication(configuration.getSauceUserName(), configuration.getSauceAccessKey());
     }
+
+    public boolean isPlatFormAndroid() {
+        return configuration.getPlatformName().equals(Platform.ANDROID);
+    }
+
+    public boolean isPlatFormiOS() {
+        return !isPlatFormAndroid();
+    }
+
 }

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -258,21 +258,21 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @Deprecated
     public MobileElement waitForElement(WebElement element) {
-        return waitForElement((MobileElement) element);
+        return waitForElement(element, configuration.getAppiumRequestTimeout());
     }
 
     @Deprecated
     public MobileElement waitForElement(WebElement element, long timeoutInSeconds) {
-        return waitForElement((MobileElement) element, timeoutInSeconds);
+        waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOf(element)), timeoutInSeconds);
+        return (MobileElement) element;
     }
 
     public MobileElement waitForElement(MobileElement element) {
-        return waitForElement(element, configuration.getAppiumRequestTimeout());
+        return waitForElement((WebElement) element);
     }
 
     public MobileElement waitForElement(MobileElement element, long timeoutInSeconds) {
-        waitForCondition(ExpectedConditions.not(ExpectedConditions.invisibilityOf(element)), timeoutInSeconds);
-        return element;
+        return waitForElement((WebElement) element, timeoutInSeconds);
     }
 
     public Locomotive click(String id) {
@@ -284,6 +284,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive click(MobileElement element) {
+        return click((WebElement) element);
+    }
+
+    @Deprecated
+    public Locomotive click(WebElement element) {
         try {
             element.click();
             return this;
@@ -292,11 +297,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         } catch (Exception exception) {
             throw exception;
         }
-    }
-
-    @Deprecated
-    public Locomotive click(WebElement element) {
-        return click((MobileElement) element);
     }
 
     public Locomotive setText(String id, String text) {
@@ -308,20 +308,20 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive setText(MobileElement element, String text) {
-        try {
-            element.clear();
-            element.sendKeys(text);
-            return this;
-        }  catch (NoSuchElementException noSuchElementException) {
-            throw new NoSuchElementException("Error: Unable to find element: " + element.toString() + " in order to set the text of the element", noSuchElementException);
-        } catch (Exception exception) {
-            throw exception;
-        }
+        return setText((WebElement) element, text);
     }
 
     @Deprecated
     public Locomotive setText(WebElement element, String text) {
-        return setText((MobileElement) element, text);
+        try {
+            element.clear();
+            element.sendKeys(text);
+            return this;
+        } catch (NoSuchElementException noSuchElementException) {
+            throw new NoSuchElementException("Error: Unable to find element: " + element.toString() + " in order to set the text of the element", noSuchElementException);
+        } catch (Exception exception) {
+            throw exception;
+        }
     }
 
     public boolean isPresent(String id) {
@@ -380,17 +380,17 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @Deprecated
     public String getText(WebElement webElement) {
-        return getText((MobileElement) webElement);
-    }
-
-    public String getText (MobileElement mobileElement) {
         try {
-            return mobileElement.getText();
+            return webElement.getText();
         } catch (NoSuchElementException noSuchElementException) {
-            throw new NoSuchElementException("Error: Unable to find element: " + mobileElement.toString() + " in order to get the text of the element", noSuchElementException);
+            throw new NoSuchElementException("Error: Unable to find element: " + webElement.toString() + " in order to get the text of the element", noSuchElementException);
         } catch (Exception exception) {
             throw exception;
         }
+    }
+
+    public String getText(MobileElement mobileElement) {
+        return getText((WebElement) mobileElement);
     }
 
     public String getAttribute(String id, String attribute) {
@@ -402,6 +402,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public String getAttribute(MobileElement element, String attribute) {
+        return getAttribute((WebElement) element, attribute);
+    }
+
+    @Deprecated
+    public String getAttribute(WebElement element, String attribute) {
         try {
             return element.getAttribute(attribute);
         } catch (NoSuchElementException noSuchElementException) {
@@ -409,11 +414,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         } catch (Exception exception) {
             throw exception;
         }
-    }
-
-    @Deprecated
-    public String getAttribute(WebElement element, String attribute) {
-        return getAttribute((MobileElement) element, attribute);
     }
 
     //region Generic swipes
@@ -438,12 +438,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, MobileElement element, float percentage) {
-        return swipe(direction, element, percentage, 0);
+        return swipe(direction, (WebElement) element, percentage);
     }
 
     @Deprecated
     public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage) {
-        return swipe(direction, (MobileElement) element, percentage);
+        return swipe(direction, element, percentage, 0);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id) {
@@ -455,12 +455,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipe(SwipeElementDirection direction, MobileElement element) {
-        return swipe(direction, element, SWIPE_DISTANCE, 0);
+        return swipe(direction, (WebElement) element);
     }
 
     @Deprecated
     public Locomotive swipe(SwipeElementDirection direction, WebElement element) {
-        return swipe(direction, (MobileElement) element);
+        return swipe(direction, element, SWIPE_DISTANCE, 0);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -473,12 +473,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
 
     public Locomotive swipe(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
-        return swipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
+        return swipe(direction, (WebElement) element, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive swipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
-        return swipe(direction, (MobileElement) element, swipeDurationInMillis);
+        return swipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
     public Locomotive swipeCenterLong(SwipeElementDirection direction) {
@@ -526,12 +526,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, MobileElement element) {
-        return swipe(direction, element, SWIPE_DISTANCE_LONG, 0);
+        return swipeLong(direction, (WebElement) element);
     }
 
     @Deprecated
     public Locomotive swipeLong(SwipeElementDirection direction, WebElement element) {
-        return swipeLong(direction, (MobileElement) element);
+        return swipe(direction, element, SWIPE_DISTANCE_LONG, 0);
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -543,22 +543,21 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive swipeLong(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
-        return swipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
-
+        return swipe(direction, (WebElement) element, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive swipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
-        return swipeLong(direction, (MobileElement) element, swipeDurationInMillis);
+        return swipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
     }
 
     public Locomotive swipe(SwipeElementDirection direction, MobileElement element, float percentage, int swipeDurationInMillis) {
-        return performSwipe(direction, false, element, percentage, swipeDurationInMillis);
+        return swipe(direction, (WebElement) element, percentage, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive swipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
-        return swipe(direction, (MobileElement) element, percentage, swipeDurationInMillis);
+        return performSwipe(direction, false, element, percentage, swipeDurationInMillis);
     }
 
     public Locomotive swipe(Point start, Point end, int swipeDurationInMillis) {
@@ -662,12 +661,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element) {
-        return longPressSwipe(direction, element, SWIPE_DISTANCE, 0);
+        return longPressSwipe(direction, (WebElement) element);
     }
 
     @Deprecated
     public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element) {
-        return longPressSwipe(direction, (MobileElement) element);
+        return longPressSwipe(direction, element, SWIPE_DISTANCE, 0);
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -679,12 +678,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
-        return longPressSwipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
+        return longPressSwipe(direction, (WebElement) element, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
-        return longPressSwipe(direction, (MobileElement) element, swipeDurationInMillis);
+        return longPressSwipe(direction, element, SWIPE_DISTANCE, swipeDurationInMillis);
     }
 
     public Locomotive longPressSwipeCenterLong(SwipeElementDirection direction) {
@@ -730,12 +729,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, MobileElement element) {
-        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, 0);
+        return longPressSwipe(direction, (WebElement) element);
     }
 
     @Deprecated
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element) {
-        return longPressSwipeLong(direction, (MobileElement) element);
+        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, 0);
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, String id, int swipeDurationInMillis) {
@@ -747,21 +746,21 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, MobileElement element, int swipeDurationInMillis) {
-        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
+        return longPressSwipeLong(direction, (WebElement) element, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive longPressSwipeLong(SwipeElementDirection direction, WebElement element, int swipeDurationInMillis) {
-        return longPressSwipeLong(direction, (MobileElement) element, swipeDurationInMillis);
+        return longPressSwipe(direction, element, SWIPE_DISTANCE_LONG, swipeDurationInMillis);
     }
 
     public Locomotive longPressSwipe(SwipeElementDirection direction, MobileElement element, float percentage, int swipeDurationInMillis) {
-        return performSwipe(direction, true, element, percentage, swipeDurationInMillis);
+        return longPressSwipe(direction, (WebElement) element, percentage, swipeDurationInMillis);
     }
 
     @Deprecated
     public Locomotive longPressSwipe(SwipeElementDirection direction, WebElement element, float percentage, int swipeDurationInMillis) {
-        return longPressSwipe(direction, (MobileElement) element, percentage, swipeDurationInMillis);
+        return performSwipe(direction, true, element, percentage, swipeDurationInMillis);
     }
 
     public Locomotive longPressSwipe(Point start, Point end, int swipeDurationInMillis) {
@@ -861,12 +860,12 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     //Overload method for using MobileElement, By, or String
     private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, MobileElement element, float percentage, int swipeDurationInMillis) {
-        return performSwipe(direction, isLongPress, getCenter(element), null, percentage, swipeDurationInMillis);
+        return performSwipe(direction, isLongPress, getCenter((WebElement) element), null, percentage, swipeDurationInMillis);
     }
 
     @Deprecated
     private Locomotive performSwipe(SwipeElementDirection direction, boolean isLongPress, WebElement element, float percentage, int swipeDurationInMillis) {
-        return performSwipe(direction, isLongPress, getCenter((MobileElement) element), null, percentage, swipeDurationInMillis);
+        return performSwipe(direction, isLongPress, getCenter(element), null, percentage, swipeDurationInMillis);
     }
 
     private Locomotive performCornerSwipe(ScreenCorner corner, SwipeElementDirection direction, float percentage, int duration) {
@@ -988,20 +987,16 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
      */
 
     public Point getCenter(MobileElement element) {
-        return new Point(getXCenter(element), getYCenter(element));
+        return getCenter((WebElement) element);
     }
 
     @Deprecated
     public Point getCenter(WebElement element) {
-        return getCenter((MobileElement) element);
+        return new Point(getXCenter(element), getYCenter(element));
     }
 
     public int getXCenter(MobileElement element) {
-        if (element == null) {
-            return getAppiumDriver().manage().window().getSize().getWidth() / 2;
-        } else {
-            return element.getLocation().getX() + (element.getSize().getWidth() / 2);
-        }
+        return getXCenter((WebElement) element);
     }
 
     public int getXCenter() {
@@ -1010,15 +1005,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @Deprecated
     public int getXCenter(WebElement element) {
-        return getXCenter((MobileElement) element);
+        if (element == null) {
+            return getAppiumDriver().manage().window().getSize().getWidth() / 2;
+        } else {
+            return element.getLocation().getX() + (element.getSize().getWidth() / 2);
+        }
     }
 
     public int getYCenter(MobileElement element) {
-        if (element == null) {
-            return getAppiumDriver().manage().window().getSize().getHeight() / 2;
-        } else {
-            return element.getLocation().getY() + (element.getSize().getHeight() / 2);
-        }
+        return getYCenter((WebElement) element);
     }
 
     public int getYCenter() {
@@ -1027,7 +1022,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
 
     @Deprecated
     public int getYCenter(WebElement element) {
-        return getYCenter((MobileElement) element);
+        if (element == null) {
+            return getAppiumDriver().manage().window().getSize().getHeight() / 2;
+        } else {
+            return element.getLocation().getY() + (element.getSize().getHeight() / 2);
+        }
     }
 
     public List<MobileElement> getElements(String id) {
@@ -1074,15 +1073,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateTextIgnoreCase(MobileElement element, String text) {
-        String actual = getText(element);
-        Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
-                text.equalsIgnoreCase(actual));
-        return this;
+        return validateTextIgnoreCase((WebElement) element, text);
     }
 
     @Deprecated
     public Locomotive validateTextIgnoreCase(WebElement element, String text) {
-        return validateTextIgnoreCase((MobileElement) element, text);
+        String actual = getText(element);
+        Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
+                text.equalsIgnoreCase(actual));
+        return this;
     }
 
     public Locomotive validateText(By by, String text) {
@@ -1090,15 +1089,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateText(MobileElement element, String text) {
-        String actual = getText(element);
-        Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
-                text.equals(actual));
-        return this;
+        return validateText((WebElement) element, text);
     }
 
     @Deprecated
     public Locomotive validateText(WebElement element, String text) {
-        return validateText((MobileElement) element, text);
+        String actual = getText(element);
+        Assert.assertTrue(String.format("Text does not match! [expected: %s] [actual: %s]", text, actual),
+                text.equals(actual));
+        return this;
     }
 
     public Locomotive validateTextNot(String id, String text) {
@@ -1114,15 +1113,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateTextNotIgnoreCase(MobileElement element, String text) {
-        String actual = getText(element);
-        Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
-                text.equalsIgnoreCase(actual));
-        return this;
+        return validateTextNotIgnoreCase((WebElement) element, text);
     }
 
     @Deprecated
     public Locomotive validateTextNotIgnoreCase(WebElement element, String text) {
-       return validateTextNotIgnoreCase((MobileElement) element, text);
+        String actual = getText(element);
+        Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
+                text.equalsIgnoreCase(actual));
+        return this;
     }
 
     public Locomotive validateTextNot(By by, String text) {
@@ -1130,15 +1129,15 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateTextNot(MobileElement element, String text) {
-        String actual = getText(element);
-        Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
-                text.equals(actual));
-        return this;
+        return validateTextNot((WebElement) element, text);
     }
 
     @Deprecated
     public Locomotive validateTextNot(WebElement element, String text) {
-        return validateTextNot((MobileElement) element, text);
+        String actual = getText(element);
+        Assert.assertFalse(String.format("Text matches! [expected: %s] [actual: %s]", text, actual),
+                text.equals(actual));
+        return this;
     }
 
     public Locomotive validateTextPresent(String text) {
@@ -1160,6 +1159,11 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
     }
 
     public Locomotive validateAttribute(MobileElement element, String attr, String expected) {
+        return validateAttribute((WebElement) element, attr, expected);
+    }
+
+    @Deprecated
+    public Locomotive validateAttribute(WebElement element, String attr, String expected) {
         String actual = null;
         try {
             actual = element.getAttribute(attr);
@@ -1183,11 +1187,6 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
                 m.find());
 
         return this;
-    }
-
-    @Deprecated
-    public Locomotive validateAttribute(WebElement element, String attr, String regex) {
-        return validateAttribute((MobileElement) element, attr, regex);
     }
 
     public Locomotive validateTrue(boolean condition) {

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveTest.java
@@ -1,6 +1,7 @@
 package com.joss.conductor.mobile;
 
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.MobileElement;
 import io.appium.java_client.TouchAction;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.appium.java_client.remote.MobileCapabilityType;
@@ -148,7 +149,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_get_center_web_element() {
-        WebElement element = mock(WebElement.class);
+        MobileElement element = mock(MobileElement.class);
         when(element.getLocation()).thenReturn(new Point(50, 0));
         when(element.getSize()).thenReturn(new Dimension(10, 10));
 
@@ -741,7 +742,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_down() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -766,7 +767,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_down_long() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -791,7 +792,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_left() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -816,7 +817,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_left_long() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -841,7 +842,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_up() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -866,7 +867,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_up_long() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -891,7 +892,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_right() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -916,7 +917,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_perform_swipe_on_element_right_long() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
         initMockDriverSizes(element);
 
         ConductorConfig[] configs = {androidConfig, iosConfig};
@@ -941,7 +942,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_getText_returns_element_text() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
 
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
@@ -953,7 +954,7 @@ public class LocomotiveTest {
 
     @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Error: Unable to find element: .*" )
     public void test_getText_returns_exception() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
 
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
@@ -965,7 +966,7 @@ public class LocomotiveTest {
 
     @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Error: Unable to find element: .*")
     public void test_setText_returns_exception() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
 
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
@@ -978,7 +979,7 @@ public class LocomotiveTest {
 
     @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Error: Unable to find element: .*")
     public void test_click_returns_exception() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
 
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
@@ -990,7 +991,7 @@ public class LocomotiveTest {
 
     @Test
     public void test_getAttribute_returns_attribute() {
-        final WebElement element = mock(WebElement.class);
+        final MobileElement element = mock(MobileElement.class);
 
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
@@ -1002,8 +1003,8 @@ public class LocomotiveTest {
 
     @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Error: Unable to find element: .*")
     public void test_getAttribute_returns_exception() {
-        final WebElement element = mock(WebElement.class);
-
+        final MobileElement element = mock(MobileElement.class);
+        
         final Locomotive locomotive = new Locomotive()
                 .setConfiguration(androidConfig)
                 .setAppiumDriver(mockDriver);


### PR DESCRIPTION
### Related Issue
closes #146

### Description
- Create methods that accept MobileElement in signature
- Deprecate methods that accept WebElement in signature
- Change return type of methods that were WebElement to MobileElement
- Modify tests to use MobileElement instead of WebElement
- Add some methods that were not created yet (but in line with our strategy of signatures of `String`, `By`, `MobileElement`)
- Add platform type boolean

### Checklist

* [x] Have you added an explanation of what your changes do?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Docs have been added / updated (for bug fixes / features)
