### PR TITLE
Reduce log level and update testng/java-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ repositories {
 ext {
     snakeYamlVersion = '1.25'
     tinyLogVersion = '1.3.6'
-    appiumJavaClientVersion = '7.2.0'
+    appiumJavaClientVersion = '7.3.0'
     glassfishJavaxAnnotationVersion = '10.0-b28'
     junitPlatformSurefireProviderVersion = '1.0.0-M3'
-    testngVersion = '6.14.3'
+    testngVersion = '7.1.0'
     assertjSwingJunitVersion = '3.4.0'
     sauceTestngVersion = '2.1.25'
 

--- a/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/ConductorConfig.java
@@ -176,7 +176,7 @@ public class ConductorConfig {
 
             if (key.equals(CUSTOM_CAPABILITIES)) {
                 putCustomCapabilities(properties.get(key));
-            } else if (key.equals("timeout") || key.equals("retries")){ //to automatically read deprecated
+            } else if (key.equals("timeout") || key.equals("retries")) { //to automatically read deprecated
                 String newKey = key.equals("timeout") ? "appiumRequestTimeout" : "implicitWaitTime";
                 System.out.println("\"" + key + "\" has been deprecated. Please remove it from your config.yaml and replace it with \"" + newKey + "\"");
                 setProperty(newKey, properties.get(key).toString());
@@ -347,7 +347,7 @@ public class ConductorConfig {
             try {
                 url = new URL(hub);
             } catch (MalformedURLException e) {
-                Logger.error("Failure parsing Hub Url", e);
+                Logger.error(e, "Failure parsing Hub Url");
             }
         }
 

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -150,7 +150,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
             DesiredCapabilities capabilities = onCapabilitiesCreated(getCapabilities(configuration));
 
             AppiumServiceBuilder builder = new AppiumServiceBuilder()
-                    .withArgument(GeneralServerFlag.LOG_LEVEL, "debug");
+                    .withArgument(GeneralServerFlag.LOG_LEVEL, "warn");
 
             switch (configuration.getPlatformName()) {
                 case ANDROID:


### PR DESCRIPTION
### Related Issue

closes #150 

### Description

We're logging too much at debug level -- this reduces the verbosity of the logs.

We are also updating testng to 7.1.0 and java client to 7.3.0

https://github.com/appium/java-client/releases
https://github.com/cbeust/testng/releases

### Checklist

* [x] Have you added an explanation of what your changes do?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Docs have been added / updated (for bug fixes / features)
