### PR TITLE
Mh/add logging when session not created

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Conductor Mobile is a port of the [Conductor](https://github.com/conductor-frame
     <dependency>
         <groupId>com.willowtreeapps</groupId>
         <artifactId>conductor-mobile</artifactId>
-        <version>0.21.0</version>
+        <version>0.21.1</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.willowtreeapps'
-version = '0.21.0'
+version = '0.21.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -201,7 +201,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         if (startCounter > configuration.getStartSessionRetries()) {
             // maximum amount of retries reached
             throw new WebDriverException(
-                    "Could not start Appium Session");
+                    "Could not start Appium Session with capabilities: " + getCapabilities(configuration));
         }
 
         // start a new session

--- a/src/main/java/com/joss/conductor/mobile/Locomotive.java
+++ b/src/main/java/com/joss/conductor/mobile/Locomotive.java
@@ -201,7 +201,7 @@ public class Locomotive extends Watchman implements Conductor<Locomotive>, Sauce
         if (startCounter > configuration.getStartSessionRetries()) {
             // maximum amount of retries reached
             throw new WebDriverException(
-                    "Could not start Appium Session with capabilities: " + getCapabilities(configuration));
+                    "Could not start Appium Session with capabilities: " + getCapabilities(configuration).toString());
         }
 
         // start a new session


### PR DESCRIPTION
```
org.openqa.selenium.WebDriverException: Could not start Appium Session
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'vdlrlctapda01', ip: '10.65.5.65', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-1062.12.1.el7.x86_64', java.version: '1.8.0_222'
Driver info: driver.version: unknown
	at com.joss.conductor.mobile.Locomotive.startAppiumSession(Locomotive.java:143)
	at com.joss.conductor.mobile.Locomotive.startAppiumSession(Locomotive.java:174)
	at com.joss.conductor.mobile.Locomotive.startAppiumSession(Locomotive.java:174)
	at com.joss.conductor.mobile.Locomotive.startAppiumSession(Locomotive.java:174)
	at com.joss.conductor.mobile.Locomotive.startAppiumSession(Locomotive.java:174)
	at com.joss.conductor.mobile.Locomotive.initialize(Locomotive.java:128)
	at com.joss.conductor.mobile.Locomotive.init(Locomotive.java:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
... Removed 16 stack frames
```

^^^ This stacktrace is very unhelpful -- trying to add more information to this