### PR TITLE
Mh/gradlew 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       #         command: sudo chmod +x ./gradlew
       - run:
           name: Check
-          command: gradle test
+          command: ./gradlew test
       - save_cache:
           paths:
             - ~/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.willowtreeapps'
-version = '0.21.2'
+version = '0.22.0-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/scripts/publish_to_maven_central.sh
+++ b/scripts/publish_to_maven_central.sh
@@ -3,5 +3,5 @@
 if [ "${CIRCLE_BRANCH}" == "master" ]; then
   echo "$MAVEN_CENTRAL_SEC_RING" | base64 -d >"$HOME"/secring.gpg
   gpg --import --batch "$HOME"/secring.gpg
-  gradle publish -Psonatype.username="$SONATYPE_USERNAME" -Psonatype.password="$SONATYPE_PASSWORD" -Psigning.keyId=0E7A8B89 -Psigning.password="$MAVEN_CENTRAL_KEY_PASSPHRASE" -Psigning.secretKeyRingFile="$HOME"/secring.gpg -Porg.gradle.parallel=false
+  ./gradlew publish -Psonatype.username="$SONATYPE_USERNAME" -Psonatype.password="$SONATYPE_PASSWORD" -Psigning.keyId=0E7A8B89 -Psigning.password="$MAVEN_CENTRAL_KEY_PASSPHRASE" -Psigning.secretKeyRingFile="$HOME"/secring.gpg -Porg.gradle.parallel=false
 fi


### PR DESCRIPTION
Prefer `/.gradlew test` over `gradle test`

`gradle test` was using the default gradle version installed on the build agent. I'd prefer to use the gradle wrapper so we can control the gradle version and prevent stuff like the 6.x + checksum bug on the previous release.